### PR TITLE
Update typedoc, fix incorrect test, fix typos, made Injector.typeId readonly, bumping version to 0.1.3

### DIFF
--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -28,7 +28,7 @@ const globalReference = getGlobal();
  * Injector type used for registering types for injection
  */
 export class Injector implements IInjector {
-    public static typeId = INJECTOR_TYPE_ID;
+    public static readonly typeId = INJECTOR_TYPE_ID;
     private _isDestroyed = false;
     private registrations = globalState(GLOBAL_REGISTRATION_MAP, () => new Map<any, IInjectionConfiguration>());
     private children = new Map<string, Injector>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,40 +38,6 @@
                 }
             }
         },
-        "@types/fs-extra": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-            "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-            "dev": true,
-            "requires": {
-                "@types/minimatch": "*",
-                "@types/node": "*"
-            }
-        },
-        "@types/handlebars": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-            "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-            "dev": true,
-            "requires": {
-                "handlebars": "*"
-            }
-        },
-        "@types/highlight.js": {
-            "version": "9.12.4",
-            "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
-            "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
-            "dev": true
-        },
         "@types/jasmine": {
             "version": "3.5.14",
             "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.14.tgz",
@@ -83,40 +49,6 @@
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
             "dev": true
-        },
-        "@types/lodash": {
-            "version": "4.14.162",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
-            "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==",
-            "dev": true
-        },
-        "@types/marked": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-            "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
-            "dev": true
-        },
-        "@types/minimatch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "14.14.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
-            "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
-            "dev": true
-        },
-        "@types/shelljs": {
-            "version": "0.8.8",
-            "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.8.tgz",
-            "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "*",
-                "@types/node": "*"
-            }
         },
         "@types/uuid": {
             "version": "3.4.9",
@@ -592,6 +524,12 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
             "dev": true
         },
         "atob": {
@@ -2608,14 +2546,15 @@
             }
         },
         "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+            "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^1.0.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -2928,9 +2867,9 @@
             }
         },
         "highlight.js": {
-            "version": "9.18.3",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
-            "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+            "version": "10.3.2",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
+            "integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw==",
             "dev": true
         },
         "hmac-drbg": {
@@ -3668,12 +3607,21 @@
             }
         },
         "jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            },
+            "dependencies": {
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
             }
         },
         "jsprim": {
@@ -3982,6 +3930,12 @@
             "integrity": "sha1-Wrh60dTB2rjowIu/A37gwZAih88=",
             "dev": true
         },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "make-dir": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -4031,9 +3985,9 @@
             }
         },
         "marked": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-            "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.3.tgz",
+            "integrity": "sha512-RQuL2i6I6Gn+9n81IDNGbL0VHnta4a+8ZhqvryXEniTb/hQNtf3i26hi1XWUhzb9BgVyWHKR3UO8MaHtKoYibw==",
             "dev": true
         },
         "md5.js": {
@@ -6317,42 +6271,36 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.14.2",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
-            "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
+            "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
             "dev": true,
             "requires": {
-                "@types/fs-extra": "^5.0.3",
-                "@types/handlebars": "^4.0.38",
-                "@types/highlight.js": "^9.12.3",
-                "@types/lodash": "^4.14.110",
-                "@types/marked": "^0.4.0",
-                "@types/minimatch": "3.0.3",
-                "@types/shelljs": "^0.8.0",
-                "fs-extra": "^7.0.0",
-                "handlebars": "^4.0.6",
-                "highlight.js": "^9.13.1",
-                "lodash": "^4.17.10",
-                "marked": "^0.4.0",
+                "fs-extra": "^9.0.1",
+                "handlebars": "^4.7.6",
+                "highlight.js": "^10.2.0",
+                "lodash": "^4.17.20",
+                "lunr": "^2.3.9",
+                "marked": "^1.1.1",
                 "minimatch": "^3.0.0",
-                "progress": "^2.0.0",
-                "shelljs": "^0.8.2",
-                "typedoc-default-themes": "^0.5.0",
-                "typescript": "3.2.x"
+                "progress": "^2.0.3",
+                "semver": "^7.3.2",
+                "shelljs": "^0.8.4",
+                "typedoc-default-themes": "^0.11.4"
             },
             "dependencies": {
-                "typescript": {
-                    "version": "3.2.4",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-                    "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
                     "dev": true
                 }
             }
         },
         "typedoc-default-themes": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-            "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
+            "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
             "dev": true
         },
         "typescript": {
@@ -6405,9 +6353,9 @@
             }
         },
         "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+            "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
             "dev": true
         },
         "unpipe": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",
@@ -55,7 +55,7 @@
         "tslint": "^5.7.0",
         "tslint-config-prettier": "^1.18.0",
         "tslint-plugin-prettier": "^2.3.0",
-        "typedoc": "^0.14.2",
+        "typedoc": "^0.19.2",
         "typescript": "~4.0.3",
         "webpack": "^4.39.2"
     },

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ import { Injectable } from '@morgan-stanley/needle';
 class MyThing {}
 ```
 
-While annotation are recommend for most use cases, you can also achieve the same using the Injector API. You gain access to this API by importing the `getRootInjector` function. 
+While annotations are recommended for most use cases, you can also achieve the same using the Injector API. You gain access to this API by importing the `getRootInjector` function. 
 
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
@@ -132,7 +132,7 @@ import { getRootInjector } from '@morgan-stanley/needle';
 getRootInjector().register(GeographyStudent, { tokens: ['geography-student'] });
 ```
 
-As stated, you are not limited to just one 1 token per type.  Simple add additional tokens to the list if you require more. 
+As stated, you are not limited to just one 1 token per type.  Simply add additional tokens to the list if you require more. 
 
 ```typescript
 import { Injectable } from '@morgan-stanley/needle';
@@ -198,8 +198,8 @@ export class PricingServiceV2 implements IPricing  {}
 
 @Injectable()
 export class CustomerPricing {
-    constructor(private @Inject('pricing') pricing: IPricing ) {
-        console.log(pricing instanceof PricingServiceV2) //True
+    constructor(@Inject('pricing') private pricing: IPricing) {
+        console.log(pricing instanceof PricingServiceV2) // true
         super();
     }
 }
@@ -241,9 +241,9 @@ getRootInjector()
 
 ## Creating strategies
 
-Strategies allows us to register multiple type providers against a given strategy key and then inject an array of all the strategies in the given consumer class. An injectable type can both exist as a strategy and pure injectable at the same time.  
+Strategies allow us to register multiple type providers against a given strategy key and then inject an array of all the strategies in the given consumer class. An injectable type can both exist as a strategy and pure injectable at the same time.  
 
-Creating strategies can be be achieved using the `@Injectable` annotation or the API. Both approaches make use of the `strategy` property on the injectable config. 
+Creating strategies can be achieved using the `@Injectable` annotation or the API. Both approaches make use of the `strategy` property on the injectable config. 
 
 ```typescript
 import { Injectable } from '@morgan-stanley/needle';
@@ -262,7 +262,7 @@ export class Strategy1 implements IStrategy {}
 export class Strategy2 implements IStrategy {}
 ```
 
-or registering view the API would look like this. 
+or registering via the API would look like this. 
 
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
@@ -306,7 +306,7 @@ console.log(strategies.length) // 2 strategies
 
 # Factories
 
-It is often the case that you need to be able to construct types with specific context or dependencies.  For these use cases you can rely of factories.
+It is often the case that you need to be able to construct types with specific context or dependencies.  For these use cases you can rely on factories.
 
 ## Registering a Factory
 
@@ -438,7 +438,7 @@ getRootInjector().configuration.maxTreeDepth = 1000;
 
 ## External Resolution Strategy
 
-In certain environments you will want to delegate the type construction to an external DI container. The `externalResolutionStrategy` is what makes this possible. When you define this strategy all construction will be delegated an the local type construction provided by this library will be ignored. 
+In certain environments you will want to delegate the type construction to an external DI container. The `externalResolutionStrategy` is what makes this possible. When you define this strategy all construction will be delegated and the local type construction provided by this library will be ignored. 
 
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
@@ -472,7 +472,7 @@ const typesWithFactories = getRegisteredTypesWithFactories() //Returns an Array<
 
 # Semantic Injection
 
-Node's module resolution works on a folder hierarchy where an applications dependencies are stored in a `node_modules` folder and dependencies can either be shared across multiple transient dependencies or localized to a specific dependencies needs. This means that if you have an npm package installed in your app that has a dependency on foo@1.1.1 and another that uses foo@2.0.0, both can co-exist in the same app domain.  
+Node's module resolution works on a folder hierarchy where an applications dependencies are stored in a `node_modules` folder and dependencies can either be shared across multiple transient dependencies or localized to a specific dependency's needs. This means that if you have an npm package installed in your app that has a dependency on foo@1.1.1 and another that uses foo@2.0.0, both can co-exist in the same app domain.  
 
 This is a powerful feature of the node/npm ecosystem and one that developers take advantage of everyday when building their apps. However, it is often the case that this semantic version isolation is not extended to your DI container.  This is something this library is trying help with.  
 
@@ -480,11 +480,11 @@ When constructing a tree of dependencies our DI container will guarantee that ea
 
 Further, due to the way npm organizes semantic versions, if you have two or more dependencies in your app that rely on foo@^1.x.x, then npm will determine what is the latest compatible version of the @foo dependency being used and then synchronize all the others to use that by de-duping out older versions.  So versions 1.1.1 and 1.2.1 would be aligned to 1.5.0 if that was being used. Read more about that [here](https://docs.npmjs.com/cli/dedupe)
 
-Semantic injection is a powerful technique for isolating change and instead letting it trickle through your system.  It can extend all the way through your package hierarchy and requires little effort from the developers to manager. 
+Semantic injection is a powerful technique for isolating change and instead letting it trickle through your system.  It can extend all the way through your package hierarchy and requires little effort from the developers to manage. 
 
 # Integrating with Angular 2+
 
-If you want to integrate this library with Angular's dependency injection system its a pretty easy thing to do.  In the `main.ts` file of your angular app you can resolve all the registered providers and then pass them to the `platformBrowserDynamic` call. 
+If you want to integrate this library with Angular's dependency injection system it's a pretty easy thing to do.  In the `main.ts` file of your Angular app you can resolve all the registered providers and then pass them to the `platformBrowserDynamic` call. 
 
 ```typescript
 import 'reflect-metadata';

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -169,7 +169,7 @@ describe('Injector', () => {
             expect(result).toBeTruthy();
         });
 
-        it('should return false if the type is injectorLike', () => {
+        it('should return false if the type is not injectorLike', () => {
             const result = isInjectorLike({});
 
             expect(result).toBeFalsy();
@@ -283,14 +283,14 @@ describe('Injector', () => {
 
             instance
                 .register(GeographyTeacher)
-                .register(Student, { tokens: ['geography-student'] })
+                .register(GeographyStudent, { tokens: ['geography-student'] })
                 .registerParamForTokenInjection('geography-student', GeographyTeacher, 0);
 
             const geographyTeacher = instance.get(GeographyTeacher);
 
             expect(geographyTeacher).toBeDefined();
             expect(geographyTeacher.student).toBeDefined();
-            expect(geographyTeacher.student instanceof GeographyStudent).toBeDefined();
+            expect(geographyTeacher.student instanceof GeographyStudent).toBeTruthy();
         });
 
         it('should resolve an instance of the type using multiple tokens', () => {


### PR DESCRIPTION
Hi @Davidhanson90,

Just a couple of small fixes to minor issues I noticed while playing around with the library.

- Fixed some typos in the readme.
- Fixed an incorrect test.
- Updated `typedoc` to latest version (`0.19.2`). Previous version was using Typescript 3.x while generating the documentation during `build-release`.
- Made `Injector.typeId` readonly to prevent reassignment.
- Bumped version to `0.1.3`.

Question: do I need to add the DCO stuff as well?