### PR TITLE
Adding support for metrics tracking inside of the injector.  

### DIFF
--- a/main/constants/constants.ts
+++ b/main/constants/constants.ts
@@ -3,4 +3,5 @@ export const DI_GLOBAL_STATE_STORE = 'needle.morganstanley.com.state.store';
 export const GLOBAL_INSTANCE_MAP = 'needle.morganstanley.com.instance.map';
 export const GLOBAL_REGISTRATION_MAP = 'needle.morganstanley.com.registrations.map';
 export const GLOBAL_CONFIGURATION = 'needle.morganstanley.com.configuration';
+export const GLOBAL_METRICS = 'needle.morganstanley.com.metrics';
 export const INJECTOR_TYPE_ID = '5495541b-7416-42a6-a830-065fe591591a';

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -72,6 +72,11 @@ export interface IConfiguration {
      * A flag that determines if a type can be registered against multiple tokens.
      */
     allowDuplicateTokens: boolean;
+
+    /**
+     * A flag indicating if metrics will be tracked for resolutions
+     */
+    trackMetrics: boolean;
 }
 
 /**
@@ -171,6 +176,7 @@ export interface IInjector {
     readonly tokenCache: ITokenCache;
     readonly parent?: IInjector;
     readonly scope?: IScopeConfiguration;
+    readonly metrics: IMetrics;
 
     /**
      * Registers a type and associated injection config with the the injector
@@ -304,4 +310,72 @@ export interface IExternalResolutionConfiguration {
      * @description By default no cache syncing is done
      */
     cacheSyncing?: boolean;
+}
+
+/**
+ * Metric record represents a single types metric information
+ */
+export interface IMetricRecord {
+    /**
+     * The type whos metrics are being tracked
+     */
+    type: any;
+    /**
+     * First activation time
+     */
+    activated: Date;
+    /**
+     * What type constructed this type. (Defaults to self if bare resolution)
+     */
+    activationTypeOwner: any;
+    /**
+     * The number of times this type has been resolved
+     */
+    resolutionCount: number;
+    /**
+     * The last time this type resolved
+     */
+    lastResolution: Date;
+    /**
+     * The number of types this type depends on based on constructor signature.
+     */
+    dependencyCount: number;
+    /**
+     * The time it took to construct this type
+     */
+    creationTimeMs: number;
+}
+
+export interface IMetrics {
+    /**
+     * Returns all the data stored in the metrics DB
+     */
+    readonly data: ReadonlyArray<Readonly<IMetricRecord>>;
+    /**
+     * Clears all the data in the metrics DB
+     */
+    clear(): void;
+    /**
+     * Dumps all the data to the console from the metric DB
+     */
+    dump(): void;
+
+    /**
+     * Gets the metrics for a given type
+     * @param type The type who's metrics we want to read
+     */
+    getMetricsForType(type: any): Readonly<IMetricRecord> | undefined;
+}
+
+/**
+ * Provides the ability to update the metrics store
+ */
+export interface IMetricsProvider extends IMetrics {
+    /**
+     * Updates a given types metrics
+     * @param type
+     * @param owner defaults to the same type if not provided
+     * @param costMs Cost in milliseconds to construct the type
+     */
+    update(type: any, owner: any, costMs: number): void;
 }

--- a/main/core/cache.ts
+++ b/main/core/cache.ts
@@ -1,40 +1,22 @@
 import { GLOBAL_INSTANCE_MAP } from '../constants/constants';
-import { Newable } from '../contracts/contracts';
+import { ICache, Newable } from '../contracts/contracts';
 import { globalState } from './globals';
 
-/**
- * Instance cache holds all instantiated injectable types.
- */
-export class InstanceCache {
+export class InstanceCache implements ICache {
     private instanceMap = globalState(GLOBAL_INSTANCE_MAP, () => new Map<any, any>());
 
-    /**
-     * Gets an instance from the cache based on the constructor type
-     * @param type
-     */
     public resolve<T extends Newable>(type: T): InstanceType<T> {
         return this.instanceMap.get(type);
     }
 
-    /**
-     * Updates or inserts a record into the instance cache
-     * @param type The constructor type
-     * @param instance the instance
-     */
-    public update(type: any, instance: any) {
+    public update(type: any, instance: any): void {
         this.instanceMap.set(type, instance);
     }
 
-    /**
-     * Clears the cache
-     */
     public clear(): void {
         this.instanceMap.clear();
     }
 
-    /**
-     * Gets the number of instances held in the cache
-     */
     public get instanceCount(): number {
         return this.instanceMap.size;
     }

--- a/main/core/configuration.ts
+++ b/main/core/configuration.ts
@@ -1,17 +1,11 @@
 import { GLOBAL_CONFIGURATION } from '../constants/constants';
-import { IExternalResolutionConfiguration } from '../contracts/contracts';
+import { IConfiguration, IExternalResolutionConfiguration } from '../contracts/contracts';
 import { globalState } from './globals';
 
 /**
  * Configurator class used for handling global container settings and behavioral flags
  */
-export class Configuration {
-    private _maxTreeDepth = 100;
-    private _externalResolutionStrategy: IExternalResolutionConfiguration | undefined;
-    private _constructUndecoratedTypes = false;
-    private _allowDuplicateTokens = false;
-    private _globalConfig = globalState(GLOBAL_CONFIGURATION, () => this);
-
+export class Configuration implements IConfiguration {
     /**
      * Gets the value indicating if the injector should attempt to construct types that have metadata but are not decorated with @Injectable
      */
@@ -70,6 +64,28 @@ export class Configuration {
     }
 
     /**
+     * Gets the flag indicating if metrics tracking is enabled
+     * @default false
+     */
+    public get trackMetrics(): boolean {
+        return this._globalConfig._trackMetrics;
+    }
+
+    /**
+     * Sets the flag to signal if metrics tracking is enabled
+     */
+    public set trackMetrics(value: boolean) {
+        this._globalConfig._trackMetrics = value;
+    }
+
+    private _maxTreeDepth = 100;
+    private _externalResolutionStrategy: IExternalResolutionConfiguration | undefined;
+    private _constructUndecoratedTypes = false;
+    private _allowDuplicateTokens = false;
+    private _globalConfig = globalState(GLOBAL_CONFIGURATION, () => this);
+    public _trackMetrics = true;
+
+    /**
      * Resets the configuration back to its default state
      */
     public reset(): void {
@@ -77,5 +93,6 @@ export class Configuration {
         this.externalResolutionStrategy = undefined;
         this.allowDuplicateTokens = false;
         this.constructUndecoratedTypes = false;
+        this._trackMetrics = false;
     }
 }

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -12,6 +12,7 @@ import {
     IInjectionConfiguration,
     IInjectionToken,
     IInjector,
+    IMetrics,
     IScopeConfiguration,
     ITokenCache,
     Newable,
@@ -23,6 +24,7 @@ import { AutoFactory } from './factory';
 import { getGlobal, globalState } from './globals';
 import { LazyInstance } from './lazy';
 import { getConstructorTypes } from './metadata.functions';
+import { Metrics } from './metrics';
 import { InjectionTokensCache } from './tokens';
 
 const globalReference = getGlobal();
@@ -40,11 +42,13 @@ export class Injector implements IInjector {
     public readonly tokenCache: ITokenCache;
     public readonly configuration: IConfiguration;
     public readonly parent?: IInjector;
+    public readonly metrics: IMetrics;
 
     constructor(
         readonly _cache: InstanceCache,
         readonly _configuration: Configuration,
         readonly _tokenCache: InjectionTokensCache,
+        readonly _metrics: Metrics,
         readonly _parent?: IInjector,
         public readonly scope?: IScopeConfiguration,
     ) {
@@ -52,6 +56,7 @@ export class Injector implements IInjector {
         this.configuration = _configuration;
         this.tokenCache = _tokenCache;
         this.parent = _parent;
+        this.metrics = this._metrics;
     }
 
     /**
@@ -186,6 +191,9 @@ export class Injector implements IInjector {
         ancestry: any[] = [],
         options?: IConstructionOptions<T>,
     ): InstanceType<T> {
+        // Measuring time taken
+        const start = Date.now();
+
         const constructorType: any =
             typeof typeOrToken === 'string' ? this.tokenCache.getTypeForToken(typeOrToken) : typeOrToken;
 
@@ -198,48 +206,53 @@ export class Injector implements IInjector {
         // We use a special ID to determine a type could be an injector type
         const isInjectorType = constructorType.typeId === Injector.typeId;
 
+        // Lets check the cache and see if we have an instance ready to service
+        let instance = this.cache.resolve(constructorType);
+
         // Support resolving Injector as injectable if found in the dependency tree
         if (isInjectorType) {
-            // Do we have a pre-cached instance?
-            const instance = this.cache.resolve(constructorType);
             if (instance == null) {
-                // Does the instance being requested share the same prototype as our current injector instance
-                if (constructorType === Injector) {
-                    this.cache.update(constructorType, this);
+                // Does the instance being requested share the same prototype as our current injector instance (Or it has no create function)
+                if (
+                    constructorType === Injector ||
+                    (constructorType !== Injector && constructorType.create === undefined)
+                ) {
+                    instance = this;
+                    this.cache.update(constructorType, instance);
                 } else {
                     /* If we are here then we have multiple injector versions in play.
                      * we check to see if the type has the static create method.  If
                      * we find it we can instance it using that method. */
-                    if (constructorType.create) {
-                        this.cache.update(constructorType, constructorType.create());
-                    } else {
-                        /* We have no create method so best we can do is service this type with the current injector
-                         * NOTE: I cannot see how we would reach here. It is more as a fallback in some very unusual
-                         * circumstance */
-                        this.cache.update(constructorType, this);
-                    }
+                    instance = constructorType.create();
+                    this.cache.update(constructorType, instance);
                 }
             }
         }
 
-        let cacheInstance = this.cache.resolve(constructorType);
-        if (cacheInstance != null) {
-            return cacheInstance;
+        if (instance == null) {
+            // If an external resolution strategy has been set, delegate all responsibility to it
+            if (this.configuration.externalResolutionStrategy != null) {
+                instance = this.configuration.externalResolutionStrategy.resolver(
+                    constructorType,
+                    (options || {}).params || [],
+                );
+                if (this.configuration.externalResolutionStrategy.cacheSyncing === true) {
+                    this.cache.update(constructorType, instance);
+                }
+            } else {
+                instance = createInstance(constructorType, true, options as any, ancestry, this);
+            }
         }
 
-        // If an external resolution strategy has been set, delegate all responsibility to it
-        if (this.configuration.externalResolutionStrategy != null) {
-            cacheInstance = this.configuration.externalResolutionStrategy.resolver(
-                constructorType,
-                (options || {}).params || [],
-            );
-            if (this.configuration.externalResolutionStrategy.cacheSyncing === true) {
-                this.cache.update(constructorType, cacheInstance);
-            }
-            return cacheInstance;
-        } else {
-            return createInstance(constructorType, true, options as any, ancestry, this);
+        // Measuring time taken
+        const end = Date.now();
+
+        // Capture metrics on this types usage
+        if (this.configuration.trackMetrics) {
+            this._metrics.update(constructorType, undefined, end - start);
         }
+
+        return instance;
     }
 
     /**
@@ -255,7 +268,7 @@ export class Injector implements IInjector {
      * construct it without doing the work externally. (no introspection required).
      */
     public static create(): Injector {
-        return new Injector(new InstanceCache(), new Configuration(), new InjectionTokensCache());
+        return new Injector(new InstanceCache(), new Configuration(), new InjectionTokensCache(), new Metrics());
     }
 
     /**
@@ -274,6 +287,7 @@ export class Injector implements IInjector {
         this.tokenCache.clear();
         this.children = new Map<string, Injector>();
         this.registrations.clear();
+        this._metrics.clear();
     }
 
     private registerStrategy(type: any, strategy: string | undefined): void {
@@ -307,4 +321,4 @@ export class Injector implements IInjector {
 
 globalReference[DI_ROOT_INJECTOR_KEY] =
     globalReference[DI_ROOT_INJECTOR_KEY] ||
-    new Injector(new InstanceCache(), new Configuration(), new InjectionTokensCache());
+    new Injector(new InstanceCache(), new Configuration(), new InjectionTokensCache(), new Metrics());

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -6,11 +6,14 @@ import { Strategy } from '../annotations/strategy';
 import { DI_ROOT_INJECTOR_KEY, GLOBAL_REGISTRATION_MAP, INJECTOR_TYPE_ID } from '../constants/constants';
 import { defaultInjectionConfiguration } from '../constants/defaults';
 import {
+    ICache,
+    IConfiguration,
     IConstructionOptions,
     IInjectionConfiguration,
     IInjectionToken,
     IInjector,
     IScopeConfiguration,
+    ITokenCache,
     Newable,
 } from '../contracts/contracts';
 import { createInstance } from '../internal/construction';
@@ -33,14 +36,23 @@ export class Injector implements IInjector {
     private registrations = globalState(GLOBAL_REGISTRATION_MAP, () => new Map<any, IInjectionConfiguration>());
     private children = new Map<string, Injector>();
     public readonly id = uuid();
+    public readonly cache: ICache;
+    public readonly tokenCache: ITokenCache;
+    public readonly configuration: IConfiguration;
+    public readonly parent?: IInjector;
 
     constructor(
-        public readonly cache: InstanceCache,
-        public readonly configuration: Configuration,
-        public readonly tokenCache: InjectionTokensCache,
-        public readonly parent?: Injector,
+        readonly _cache: InstanceCache,
+        readonly _configuration: Configuration,
+        readonly _tokenCache: InjectionTokensCache,
+        readonly _parent?: IInjector,
         public readonly scope?: IScopeConfiguration,
-    ) {}
+    ) {
+        this.cache = _cache;
+        this.configuration = _configuration;
+        this.tokenCache = _tokenCache;
+        this.parent = _parent;
+    }
 
     /**
      * Registers a type and associated injection config with the the injector
@@ -130,7 +142,7 @@ export class Injector implements IInjector {
 
         // Remove ourselves from the parent scope if not root.
         if (this.parent != null) {
-            this.parent.children.delete(this.id);
+            (this.parent as Injector).children.delete(this.id);
         }
         this._isDestroyed = true;
     }

--- a/main/core/metrics.ts
+++ b/main/core/metrics.ts
@@ -1,0 +1,49 @@
+import { GLOBAL_METRICS } from 'main/constants/constants';
+import { IMetricRecord, IMetricsProvider } from 'main/contracts/contracts';
+import { globalState } from './globals';
+import { getConstructorTypes } from './metadata.functions';
+
+export class Metrics implements IMetricsProvider {
+    public get data() {
+        return Array.from(this._metrics).map(([_item, value]) => value);
+    }
+    private _metrics = globalState(GLOBAL_METRICS, () => new Map<any, IMetricRecord>());
+
+    public clear(): void {
+        this._metrics.clear();
+    }
+
+    public getMetricsForType(type: any): Readonly<IMetricRecord> | undefined {
+        return this._metrics.get(type);
+    }
+
+    public dump(): void {
+        if (console.table) {
+            console.table(this.data);
+        } else {
+            console.log(this.data);
+        }
+    }
+
+    public update(type: any, owner: any, creationTimeMs: number): void {
+        // First time init lets create a record
+        if (!this._metrics.has(type)) {
+            this._metrics.set(type, {
+                activated: new Date(),
+                activationTypeOwner: owner || type,
+                creationTimeMs,
+                dependencyCount: getConstructorTypes(type).length,
+                lastResolution: new Date(),
+                resolutionCount: 0,
+                type,
+            });
+        }
+
+        const record = this._metrics.get(type);
+        // Lets update the values that matter
+        if (record != null) {
+            record.lastResolution = new Date();
+            record.resolutionCount++;
+        }
+    }
+}

--- a/main/core/tokens.ts
+++ b/main/core/tokens.ts
@@ -3,6 +3,7 @@ import {
     IInjectionToken,
     ILazyParameterInjectionToken,
     IParameterInjectionToken,
+    ITokenCache,
 } from '../contracts/contracts';
 import { globalState } from './globals';
 import { isConstructorParameterToken } from './guards';
@@ -10,7 +11,7 @@ import { isConstructorParameterToken } from './guards';
 /**
  * The injection token cache is used to store all uses of the @Inject annotation.
  */
-export class InjectionTokensCache {
+export class InjectionTokensCache implements ITokenCache {
     private injectParameterTokens = globalState(
         'GLOBAL_INJECTION_PARAMETER_TOKENS',
         () => new Map<any, IParameterInjectionToken[]>(),
@@ -34,73 +35,37 @@ export class InjectionTokensCache {
     private tokensToTypes = globalState('GLOBAL_TOKENS_TO_TYPES', () => new Map<string, any[]>());
     private strategyConsumers = globalState('GLOBAL_STRATEGY_CONSUMERS', () => new Map<string, any[]>());
 
-    /**
-     * Get a list of associated inject parameter tokens for the given constructor of a type
-     * @param type
-     */
     public getInjectTokens(type: any): IParameterInjectionToken[] {
         return [...(this.injectParameterTokens.get(type) || [])];
     }
 
-    /**
-     * Get a list of associated strategy parameter tokens for the given constructor of a type
-     * @param type
-     */
     public getStrategyTokens(type: any): IParameterInjectionToken[] {
         return [...(this.strategyParameterTokens.get(type) || [])];
     }
 
-    /**
-     * Get a list of associated factory parameter tokens for the given constructor of a type
-     * @param type
-     */
     public getFactoryTokens(type: any): IParameterInjectionToken[] {
         return [...(this.factoryParameterTokens.get(type) || [])];
     }
 
-    /**
-     * Get a list of associated lazy parameter tokens for the given constructor of a type
-     * @param type
-     */
     public getLazyTokens(type: any): IParameterInjectionToken[] {
         return [...(this.lazyParameterTokens.get(type) || [])];
     }
-
-    /**
-     * Gets a list of tokens this type has be registered against
-     */
     public getTokensForType(type: any): IInjectionToken[] {
         return [...(this.typeToTokens.get(type) || [])];
     }
 
-    /**
-     * Gets a list of types registered against this token
-     * @param token
-     */
     public getTypesForToken(token: string): any[] {
         return [...(this.tokensToTypes.get(token) || [])];
     }
 
-    /**
-     * Gets a list of types which are consumers of the given strategy key
-     * @param token
-     */
     public getStrategyConsumers(token: string): any[] {
         return [...(this.strategyConsumers.get(token) || [])];
     }
 
-    /**
-     * Gets the type associated to this token.  Note, if there are many it will return the last one registered
-     * @param token
-     */
     public getTypeForToken(token: string): any | undefined {
         return this.getTypesForToken(token).pop();
     }
 
-    /**
-     * Register either constructor parameter token or Type injection token
-     * @param metadata
-     */
     public register(
         metadata:
             | IParameterInjectionToken

--- a/main/index.ts
+++ b/main/index.ts
@@ -6,7 +6,6 @@ export * from './annotations/lazy';
 export * from './core/factory';
 export * from './core/lazy';
 export * from './core/metadata.functions';
-export * from './core/configuration';
 export * from './core/util.functions.partial';
 export * from './core/util.functions';
 export * from './core/injector';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6315,9 +6315,9 @@
             }
         },
         "typescript": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-            "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+            "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.4",
+    "version": "1.0.0",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",
@@ -56,11 +56,11 @@
         "tslint-config-prettier": "^1.18.0",
         "tslint-plugin-prettier": "^2.3.0",
         "typedoc": "^0.16.1",
-        "typescript": "~3.2.4",
+        "typescript": "~3.4.5",
         "webpack": "^4.39.2"
     },
     "peerDependencies": {
-        "typescript": ">=3.2"
+        "typescript": ">=3.4"
     },
     "repository": {
         "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -414,6 +414,77 @@ const instance = get(Vehicle);
 console.log(instance === vehicle) // True
 ```
 
+# Metrics tracking
+
+The injector tracks metrics about your injectable types during runtime.  There are a range of different values captured and these are stored in the metrics provider which is accessible via the Injector type.  The data is store as records and the below type shows the information captured.  
+
+```typescript
+export interface IMetricRecord {
+    /**
+     * The type who's metrics are being tracked
+     */
+    type: any;
+    /**
+     * First activation time
+     */
+    activated: Date;
+    /**
+     * What type constructed this type. (Defaults to self if bare resolution)
+     */
+    activationTypeOwner: any;
+    /**
+     * The number of times this type has been resolved
+     */
+    resolutionCount: number;
+    /**
+     * The last time this type resolved
+     */
+    lastResolution: Date;
+    /**
+     * The number of types this type depends on based on constructor signature.
+     */
+    dependencyCount: number;
+    /**
+     * The time it took to construct this type
+     */
+    creationTimeMs: number;
+}
+```
+
+## Reading the metric data
+
+There are a number of ways to read the metric data.  To access via the injector instance simply do the following. 
+
+```typescript
+import { getRootInjector } from '@morgan-stanley/needle';
+
+const metrics = getRootInjector().metrics;
+```
+
+You can easily `dump` the data to the console using the following.  
+
+```typescript
+getRootInjector().metrics.dump();
+```
+
+You can reset the metrics by calling the `reset` method.
+
+```typescript
+getRootInjector().metrics.reset();
+```
+
+You read the metrics for a specific type by using the `getMetricsForType` method. 
+
+```typescript
+getRootInjector().metrics.getMetricsForType(MyType);
+```
+
+You an read all the metric data by reading the `data` property. 
+
+```typescript
+const records: IMetricRecord[] = getRootInjector().metrics.data;
+```
+
 # Global configuration
 
 ## Construct Undecorated Types
@@ -434,6 +505,16 @@ When constructing a tree of dependencies the hierarchy can get very deep, this i
 import { getRootInjector } from '@morgan-stanley/needle';
 
 getRootInjector().configuration.maxTreeDepth = 1000;
+```
+
+## Track metrics
+
+By default the injector will track common metric information about types in the system.  This includes information such as first activation time, number of resolutions, cost of construction etc.  You can disable metrics tracking by setting the `trackMetrics` flag to false.  
+
+```typescript
+import { getRootInjector } from '@morgan-stanley/needle';
+
+getRootInjector().configuration.trackMetrics = false;
 ```
 
 ## External Resolution Strategy

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -1,6 +1,8 @@
+/* INTERNALS */
+import { Configuration } from 'main/core/configuration';
+/* INTERNALS */
 import {
     AutoFactory,
-    Configuration,
     Factory,
     getRootInjector,
     Inject,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "lib": [
             "ES5",
             "ES6",
-            "DOM"
+            "DOM",
         ],
         "declaration": true,
         "sourceMap": true,


### PR DESCRIPTION
This PR adds basic support for metrics tracking.  Plan is to extends this information later with support for other types of metrics such as

- Is the type being used in a factory, strategy or lazy
- Is the type scoped at any point
- What types depend on this type.  

There is also consideration for a metrics viewer to view the data.  