### PR TITLE
Support passing explicit null/undefined values to factory functions

### DIFF
--- a/main/constants/constants.ts
+++ b/main/constants/constants.ts
@@ -2,3 +2,13 @@ export const DI_ROOT_INJECTOR_KEY = 'needle.morganstanley.com.root.injector';
 export const INJECTOR_TYPE_ID = '5495541b-7416-42a6-a830-065fe591591a';
 
 export type InjectorIdentifier = string;
+
+/**
+ * Represents a null value to the injector so it can discriminate against null
+ */
+export const NULL_VALUE = { type: 'NULL_VALUE' };
+
+/**
+ * Represents a undefined value to the injector so it can discriminate against null
+ */
+export const UNDEFINED_VALUE = { type: 'UNDEFINED_VALUE' };

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -3,7 +3,13 @@ import { Factory } from '../annotations/factory';
 import { Inject } from '../annotations/inject';
 import { Lazy } from '../annotations/lazy';
 import { Strategy } from '../annotations/strategy';
-import { DI_ROOT_INJECTOR_KEY, INJECTOR_TYPE_ID, InjectorIdentifier } from '../constants/constants';
+import {
+    DI_ROOT_INJECTOR_KEY,
+    INJECTOR_TYPE_ID,
+    InjectorIdentifier,
+    NULL_VALUE,
+    UNDEFINED_VALUE,
+} from '../constants/constants';
 import { defaultInjectionConfiguration } from '../constants/defaults';
 import {
     ICache,
@@ -422,9 +428,14 @@ export class Injector implements IInjector {
         } = this.getConstructorsParamTokens(injector, type);
 
         return constructorParamTypes.map((paramType, index) => {
-            // Have they provided a value, if they have use it, if its undefined construct using the type
+            // Have they provided a value, if they have use it, if its undefined (Not explicit NULL_VALUE or UNDEFINED_VALUE) construct using the type
             const value = overrideParams[index];
             if (value != null) {
+                if (value === UNDEFINED_VALUE) {
+                    return undefined;
+                } else if (value === NULL_VALUE) {
+                    return null;
+                }
                 return value;
             }
 

--- a/readme.md
+++ b/readme.md
@@ -352,6 +352,21 @@ const carWithSuperPowerfulEngine = factory.create(new SuperPowerfulEngine());
 
 ```
 
+If you would **not** like the injector to auto resolve the value for engine and you wanted to actually return `null` or `undefined` you can use well known injector values to achieve this.  
+
+```typescript
+
+@Injectable()
+import { NULL_VALUE, UNDEFINED_VALUE} from '@morgan-stanley/needle';
+
+const factory:  AutoFactory<typeof Car> = getRootInjector().getFactory(Car);
+const carWithEmptyEngine = factory.create(UNDEFINED_VALUE, 4);
+const carWithNoEngine = factory.create(NULL_VALUE);
+
+carWithEmptyEngine.engine === undefined //True
+carWithNoEngine.engine === null //True
+```
+
 # Lazy injection
 
 In certain situations, constructing the entire dependency tree can either be expensive or alternatively might introduce side effects you want to avoid.  In those cases `Lazy` injectables can be useful. Lazy injectables provide a placeholder injection type of `LazyInstance<T>` which will only construct the target injectable when its value property is read. 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -14,7 +14,7 @@ import {
     LazyInstance,
     Strategy,
 } from '../main';
-import { DI_ROOT_INJECTOR_KEY } from '../main/constants/constants';
+import { DI_ROOT_INJECTOR_KEY, NULL_VALUE, UNDEFINED_VALUE } from '../main/constants/constants';
 import { InstanceCache } from '../main/core/cache';
 import { isInjectorLike } from '../main/core/guards';
 import { InjectionTokensCache } from '../main/core/tokens';
@@ -572,6 +572,32 @@ describe('Injector', () => {
             expect(carFactory).toBeDefined();
             expect(car).toBeDefined();
             expect(car.engine).toBeDefined();
+        });
+
+        it('should resolve a undefined if explicitly passed', () => {
+            const instance = getInstance();
+
+            instance.register(Car).register(Engine);
+
+            const carFactory = instance.getFactory(Car);
+            const car = carFactory.create(UNDEFINED_VALUE);
+
+            expect(carFactory).toBeDefined();
+            expect(car).toBeDefined();
+            expect(car.engine).toBeUndefined();
+        });
+
+        it('should resolve a null value if explicitly passed', () => {
+            const instance = getInstance();
+
+            instance.register(Car).register(Engine);
+
+            const carFactory = instance.getFactory(Car);
+            const car = carFactory.create(NULL_VALUE);
+
+            expect(carFactory).toBeDefined();
+            expect(car).toBeDefined();
+            expect(car.engine).toBeNull();
         });
 
         it('should return a new instance of a car on each create request', () => {


### PR DESCRIPTION
This PR fixes a gap in autofactory implementation.  Currently passing undefined to the create method signals to the injector that the value in that index position should be auto resolved.  There are times when you do want to pass an explict null or undefined.  To support this I have now added two well known constants which can be used in conjuction with factories.  

```typescript
@Injectable()
import { NULL_VALUE, UNDEFINED_VALUE} from '@morgan-stanley/needle';

const factory:  AutoFactory<typeof Car> = getRootInjector().getFactory(Car);
const carWithEmptyEngine = factory.create(UNDEFINED_VALUE, 4);
const carWithNoEngine = factory.create(NULL_VALUE);

carWithEmptyEngine.engine === undefined //True
carWithNoEngine.engine === null //True
```