### PR TITLE
Support for using Symbols for token registration/resolution

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "editor.tabSize": 4,
     "editor.detectIndentation": false,
     "typescript.tsdk": "node_modules\\typescript\\lib",
-    "tslint.configFile": "tslint.conf.js"
+    "tslint.configFile": "tslint.conf.js",
+    "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/main/annotations/factory.ts
+++ b/main/annotations/factory.ts
@@ -18,7 +18,7 @@ export function Factory(factoryTarget: Newable) {
             factoryTarget,
             property,
             index,
-            tokenType: 'factory',
+            injectionType: 'factory',
         });
     }
 

--- a/main/annotations/inject.ts
+++ b/main/annotations/inject.ts
@@ -1,3 +1,4 @@
+import { StringOrSymbol } from '../contracts/contracts';
 import { getRootInjector } from '../core/util.functions';
 
 /**
@@ -6,7 +7,7 @@ import { getRootInjector } from '../core/util.functions';
  * @Injectable()
  * class Foo(@Inject('my-token') foo: Foo) {}
  */
-export function Inject(token: string) {
+export function Inject(token: StringOrSymbol) {
     // the original decorator
     function inject(target: any, property: string | symbol | undefined, index: number): void {
         getRootInjector().tokenCache.register({
@@ -14,7 +15,7 @@ export function Inject(token: string) {
             owner: target,
             property,
             index,
-            tokenType: 'singleton',
+            injectionType: 'singleton',
         });
     }
 

--- a/main/annotations/lazy.ts
+++ b/main/annotations/lazy.ts
@@ -18,7 +18,7 @@ export function Lazy(lazyTarget: Newable) {
             lazyTarget,
             property,
             index,
-            tokenType: 'lazy',
+            injectionType: 'lazy',
         });
     }
 

--- a/main/annotations/strategy.ts
+++ b/main/annotations/strategy.ts
@@ -1,9 +1,10 @@
+import { StringOrSymbol } from '../contracts/contracts';
 import { getRootInjector } from '../core/util.functions';
 
 /**
  * The @Strategy annotation allows you inject an array of strategy types registered against the given key
  */
-export function Strategy(strategyName: string) {
+export function Strategy(strategyName: StringOrSymbol) {
     // the original decorator
     function strategy(target: any, property: string | symbol | undefined, index: number): void {
         getRootInjector().tokenCache.register({
@@ -11,7 +12,7 @@ export function Strategy(strategyName: string) {
             owner: target,
             property,
             index,
-            tokenType: 'multiple',
+            injectionType: 'multiple',
         });
     }
 

--- a/main/constants/constants.ts
+++ b/main/constants/constants.ts
@@ -1,8 +1,6 @@
 export const DI_ROOT_INJECTOR_KEY = 'needle.morganstanley.com.root.injector';
 export const INJECTOR_TYPE_ID = '5495541b-7416-42a6-a830-065fe591591a';
 
-export type InjectorIdentifier = string;
-
 /**
  * Represents a null value to the injector so it can discriminate against null
  */

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -1,10 +1,13 @@
-import { InjectorIdentifier } from 'main/constants/constants';
 import { AutoFactory } from '../core/factory';
 import { LazyInstance } from '../core/lazy';
 
+export type InjectorIdentifier = string;
+
+export type StringOrSymbol = string | symbol;
+
 export type InstanceFactory = () => InstanceType<any>;
 
-export type TokenType = 'singleton' | 'multiple' | 'factory' | 'lazy';
+export type InjectionType = 'singleton' | 'multiple' | 'factory' | 'lazy';
 
 export type Newable = new (...args: any[]) => any;
 
@@ -26,16 +29,16 @@ export type OptionalConstructorParameters<T extends new (...args: any) => any> =
  * Injection token interface
  */
 export interface IInjectionToken {
-    token: string;
+    token: StringOrSymbol;
     owner: any;
-    tokenType: TokenType;
+    injectionType: InjectionType;
 }
 
 /**
  * Injection token parameter metadata.
  */
 export interface IParameterInjectionToken extends IInjectionToken {
-    property: string | symbol;
+    property: StringOrSymbol;
     index: number;
 }
 
@@ -133,17 +136,17 @@ export interface ITokenCache {
      * Gets a list of types registered against this token
      * @param token
      */
-    getTypesForToken(token: string): any[];
+    getTypesForToken(token: StringOrSymbol): any[];
     /**
      * Gets a list of types which are consumers of the given strategy key
      * @param token
      */
-    getStrategyConsumers(token: string): any[];
+    getStrategyConsumers(token: StringOrSymbol): any[];
     /**
      * Gets the type associated to this token.  Note, if there are many it will return the last one registered
      * @param token
      */
-    getTypeForToken(token: string): any | undefined;
+    getTypeForToken(token: StringOrSymbol): any | undefined;
 
     /**
      * Register either constructor parameter token or Type injection token
@@ -204,12 +207,12 @@ export interface IInjector {
     /**
      * Registers a parameter for token injection.  This maps to the @Inject annotation
      */
-    registerParamForTokenInjection(token: string, ownerType: any, index: number): this;
+    registerParamForTokenInjection(token: StringOrSymbol, ownerType: any, index: number): this;
 
     /**
      * Registers a parameter for strategy injection.  This maps to the @Strategy annotation
      */
-    registerParamForStrategyInjection(strategy: string, ownerType: any, index: number): this;
+    registerParamForStrategyInjection(strategy: StringOrSymbol, ownerType: any, index: number): this;
     /**
      * Determine if this is the root injector
      */
@@ -247,7 +250,7 @@ export interface IInjector {
      * Gets an instance of a given type
      */
     get<T extends Newable>(
-        typeOrToken: T | string,
+        typeOrToken: T | StringOrSymbol,
         ancestry?: any[],
         options?: IConstructionOptions<T>,
     ): InstanceType<T>;
@@ -260,7 +263,7 @@ export interface IInjector {
     /**
      * Returns an Array of strategy types for the given strategy token
      */
-    getStrategies<T = unknown>(strategy: string): Array<T>;
+    getStrategies<T = unknown>(strategy: StringOrSymbol): Array<T>;
 
     /**
      * Returns an array of all the types registered in the container with associated constructor dependencies
@@ -293,12 +296,12 @@ export interface IInjectionConfiguration {
     /**
      * A list of tokens that this injectable can be resolved by using the @Inject("token") annotation
      */
-    tokens?: Array<string> | undefined;
+    tokens?: Array<StringOrSymbol> | undefined;
 
     /**
      * The strategy property works in conjunction with the @Strategy("key") annotation and signals that an array of items can be injected under this key
      */
-    strategy?: string;
+    strategy?: StringOrSymbol;
 }
 
 /**

--- a/main/core/guards.ts
+++ b/main/core/guards.ts
@@ -4,6 +4,7 @@ import {
     IInjector,
     ILazyParameterInjectionToken,
     IParameterInjectionToken,
+    StringOrSymbol,
 } from '../contracts/contracts';
 
 /**
@@ -37,6 +38,14 @@ export function isLazyParameterToken(
     item: IInjectionToken | ILazyParameterInjectionToken,
 ): item is ILazyParameterInjectionToken {
     return isConstructorParameterToken(item) && item.lazyTarget != null;
+}
+
+/**
+ * Determines if the value is a string or symbol
+ * @param item The value being tested
+ */
+export function isStringOrSymbol(item: any): item is StringOrSymbol {
+    return typeof item === 'string' || typeof item === 'symbol';
 }
 
 /**

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -551,7 +551,7 @@ export class Injector implements IInjector {
         return { injectionParamTokens, strategyParamTokens, factoryParamTokens, lazyParamTokens };
     }
 
-    private registerStrategy(type: any, strategy: StringOrSymbol): void {
+    private registerStrategy(type: any, strategy: StringOrSymbol | undefined): void {
         if (isStringOrSymbol(strategy)) {
             const token: IInjectionToken = { token: strategy, owner: type, injectionType: 'multiple' };
             this.tokenCache.register(token);
@@ -566,11 +566,11 @@ export class Injector implements IInjector {
                     const tokenTypes = this.tokenCache.getTypesForToken(t.token);
                     if (tokenTypes.length > 0) {
                         throw new Error(
-                            `Cannot register Type '${
+                            `Cannot register Type [${
                                 (type as any).name
-                            }' with token ${t.token.toString()}. Duplicate token found for the following type '${tokenTypes
+                            }] with token '${t.token.toString()}'. Duplicate token found for the following type [${tokenTypes
                                 .map(tt => tt.name)
-                                .join(' -> ')}'`,
+                                .join(' -> ')}]`,
                         );
                     }
                 }

--- a/main/core/metrics.ts
+++ b/main/core/metrics.ts
@@ -1,4 +1,4 @@
-import { IMetricRecord, IMetricsProvider } from 'main/contracts/contracts';
+import { IMetricRecord, IMetricsProvider } from '../contracts/contracts';
 import { getConstructorTypes } from './metadata.functions';
 
 export class Metrics implements IMetricsProvider {

--- a/main/core/tokens.ts
+++ b/main/core/tokens.ts
@@ -4,6 +4,7 @@ import {
     ILazyParameterInjectionToken,
     IParameterInjectionToken,
     ITokenCache,
+    StringOrSymbol,
 } from '../contracts/contracts';
 import { isConstructorParameterToken } from './guards';
 
@@ -17,8 +18,8 @@ export class InjectionTokensCache implements ITokenCache {
     private lazyParameterTokens = new Map<any, IParameterInjectionToken[]>();
     // Fast reverse lookups.  Need to improve
     private typeToTokens = new Map<any, IInjectionToken[]>();
-    private tokensToTypes = new Map<string, any[]>();
-    private strategyConsumers = new Map<string, any[]>();
+    private tokensToTypes = new Map<StringOrSymbol, any[]>();
+    private strategyConsumers = new Map<StringOrSymbol, any[]>();
 
     public getInjectTokens(type: any): IParameterInjectionToken[] {
         return [...(this.injectParameterTokens.get(type) || [])];
@@ -39,15 +40,15 @@ export class InjectionTokensCache implements ITokenCache {
         return [...(this.typeToTokens.get(type) || [])];
     }
 
-    public getTypesForToken(token: string): any[] {
+    public getTypesForToken(token: StringOrSymbol): any[] {
         return [...(this.tokensToTypes.get(token) || [])];
     }
 
-    public getStrategyConsumers(token: string): any[] {
+    public getStrategyConsumers(token: StringOrSymbol): any[] {
         return [...(this.strategyConsumers.get(token) || [])];
     }
 
-    public getTypeForToken(token: string): any | undefined {
+    public getTypeForToken(token: StringOrSymbol): any | undefined {
         return this.getTypesForToken(token).pop();
     }
 
@@ -82,12 +83,12 @@ export class InjectionTokensCache implements ITokenCache {
      * Registers all the types token information explicitly defined in @Injectable
      */
     private registerTypeTokens(metadata: IInjectionToken) {
-        if (metadata.tokenType === 'singleton') {
+        if (metadata.injectionType === 'singleton') {
             // Update the lookup for tokens -> types
             this.typeToTokens.set(metadata.owner, [...this.getTokensForType(metadata.owner), metadata]);
             // Update the reverse lookup for types -> token
             this.tokensToTypes.set(metadata.token, [...this.getTypesForToken(metadata.token), metadata.owner]);
-        } else if (metadata.tokenType === 'multiple') {
+        } else if (metadata.injectionType === 'multiple') {
             this.strategyConsumers.set(metadata.token, [
                 ...this.getStrategyConsumers(metadata.token),
                 [metadata.owner],
@@ -99,13 +100,13 @@ export class InjectionTokensCache implements ITokenCache {
      * Registers all the tokens used in a constructor such as @Inject, @Strategy, @Factory, @Lazy
      */
     private registerParameterTokens(metadata: IParameterInjectionToken) {
-        if (metadata.tokenType === 'singleton') {
+        if (metadata.injectionType === 'singleton') {
             this.injectParameterTokens.set(metadata.owner, [...this.getInjectTokens(metadata.owner), metadata]);
-        } else if (metadata.tokenType === 'multiple') {
+        } else if (metadata.injectionType === 'multiple') {
             this.strategyParameterTokens.set(metadata.owner, [...this.getStrategyTokens(metadata.owner), metadata]);
-        } else if (metadata.tokenType === 'factory') {
+        } else if (metadata.injectionType === 'factory') {
             this.factoryParameterTokens.set(metadata.owner, [...this.getFactoryTokens(metadata.owner), metadata]);
-        } else if (metadata.tokenType === 'lazy') {
+        } else if (metadata.injectionType === 'lazy') {
             this.lazyParameterTokens.set(metadata.owner, [...this.getLazyTokens(metadata.owner), metadata]);
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,14 @@ The library depends on TypeScript's support for decorators. Therefore you must e
 
 # Polyfills
 
-This library requires modern browsers supporting `Maps` or an appropriate polyfill. It also makes use of a `reflect-metadata` polyfill for performing runtime introspection.  You can install the reflect-metadata polyfill with 
+This library will work with modern browsers and JavaScript run-times without the need for polyfills, however if targeting older browsers like IE11 you will need to provide a polyfill for the following types. 
+
+* Map - [Read about the Map type here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+* Symbol - [Read about the Symbol type here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
+
+**Note** Symbol support is optional and only required if you intend to use Symbols for your token registrations.  
+
+This library also makes use of the `reflect-metadata` [API](https://rbuckton.github.io/reflect-metadata/) for performing runtime introspection. Most browsers will not support this therefore you must install this yourself. 
 
 ```typescript
 npm install reflect-metadata
@@ -109,7 +116,7 @@ console.log(thing1 === thing2) //True
 
 # Tokens
 
-Tokens allow us to provide a marker to the injector whereby the type we are going to be injecting either cannot be imported or we wish to use an interface instead.  Every injectable in the system can be registered with either zero or more tokens.  A single type can register itself against multiple tokens.  
+Tokens allow us to provide a marker to the injector whereby the type we are going to be injecting either cannot be imported or we wish to use an interface instead.  Every injectable in the system can be registered with either zero or more tokens.  A single type can register itself against multiple tokens.  Tokens can be defined using a `string` or `symbol`
 
 ## Registering with tokens
 
@@ -142,9 +149,27 @@ import { Injectable } from '@morgan-stanley/needle';
 })
 export class GeographyStudent extends Student {}
 ```
+
+## Registering Symbols for tokens
+
+Using strings as tokens for most teams is perfectly acceptable, however often in large code bases it is possible to run into naming collisions.  In order to resolve this issue you can instead adopt `Symbols` instead to define your tokens.  Below is an example of two registrations where the Symbol names overlap but will not pollute each other when resolutions are made as Symbols are unique. 
+
+```typescript
+import { getRootInjector } from '@morgan-stanley/needle';
+
+const pricingSymbol1 = Symbol.for('pricing');
+const pricingSymbol2 = Symbol.for('pricing');
+
+getRootInjector().configuration.allowDuplicateTokens = false;
+
+getRootInjector()
+    .register(PricingServiceV1, { tokens: [pricingSymbol1] })
+    .register(PricingServiceV2, { tokens: [pricingSymbol2] }); //No exception thrown as Symbols are unique
+```
+
 ## Resolving by token
 
-To resolve a type by token we can make use of the `@Inject` annotation. In the constructor of a given injectable we can mark one of the parameters with `@Inject` providing a token which we wish to resolve. Note, the parameter type does not need to match the type of the injected value.  This is what allows us to use either interfaces or a super type as a replacement for the real type. 
+To resolve a type by token we can make use of the `@Inject` annotation. In the constructor of a given injectable we can mark one of the parameters with `@Inject` providing a token which we wish to resolve. Note, the parameter type does not need to match the type of the injected value.  This is what allows us to use either interfaces or a sub type as a replacement for the real type. 
 
 ```typescript
 @Injectable()
@@ -245,6 +270,8 @@ Strategies allow us to register multiple type providers against a given strategy
 
 Creating strategies can be achieved using the `@Injectable` annotation or the API. Both approaches make use of the `strategy` property on the injectable config. 
 
+## Registering strategies
+
 ```typescript
 import { Injectable } from '@morgan-stanley/needle';
 
@@ -277,6 +304,20 @@ getRootInjector()
 
 ```
 
+To avoid naming conflicts that can occur with strings, you can also use `symbols` for your strategy names.  Below is an example of this using the registration API.
+
+```typescript
+import { getRootInjector } from '@morgan-stanley/needle';
+const strategySymbol = Symbol.for('work-strategies');
+
+getRootInjector()
+    .register(Strategy1, {
+        strategy: strategySymbol,
+    })
+    .register(Strategy2, {
+        strategy: strategySymbol,
+    });
+```
 ## Resolving strategies
 
 When it comes to injecting lists of strategies we can use the `@Strategy` annotation to mark that we expect an array of strategies.  You can register consumers of strategies using this annotation or the API.  

--- a/readme.md
+++ b/readme.md
@@ -611,16 +611,6 @@ level2.isDestroyed() //True;
 
 # Global configuration
 
-## Construct Undecorated Types
-
-When constructing a tree of dependencies you may encounter types in that tree that have no registrations associated to them. In this case you can set the configuration to `constructUndecoratedTypes`.  By default this value is set to `false` changing it to true will avoid an error that would normally be thrown. 
-
-```typescript
-import { getRootInjector } from '@morgan-stanley/needle';
-
-getRootInjector().configuration.constructUndecoratedTypes = true;
-```
-
 ## Max tree depth
 
 When constructing a tree of dependencies the hierarchy can get very deep, this is especially so if a circular reference is encountered.  Determining if this is the case can be difficult which is where `maxTreeDepth` can help.  Setting this value (`defaults to 500`) will set a max limit on the depth of the tree being created. If the limit is reached an exception will be thrown. 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -375,6 +375,53 @@ describe('Injector', () => {
             expect(daughter).toBe(son);
         });
 
+        it('should throw an error if we try and register two types sharing the same String token and allowDuplicateTokens=false.', () => {
+            const instance = getInstance();
+
+            instance.configuration.allowDuplicateTokens = false;
+            let message = '';
+
+            instance.register(Child, {
+                tokens: ['child'],
+            });
+
+            try {
+                instance.register(Parent, {
+                    tokens: ['child'],
+                });
+            } catch (ex) {
+                message = ex.message;
+            }
+
+            expect(message).toBe(
+                "Cannot register Type [Parent] with token 'child'. Duplicate token found for the following type [Child]",
+            );
+        });
+
+        it('should throw an error if we try and register two types sharing the same Symbol token and allowDuplicateTokens=false.', () => {
+            const instance = getInstance();
+
+            const symbol = Symbol.for('child');
+            instance.configuration.allowDuplicateTokens = false;
+            let message = '';
+
+            instance.register(Child, {
+                tokens: [symbol],
+            });
+
+            try {
+                instance.register(Parent, {
+                    tokens: [symbol],
+                });
+            } catch (ex) {
+                message = ex.message;
+            }
+
+            expect(message).toBe(
+                "Cannot register Type [Parent] with token 'Symbol(child)'. Duplicate token found for the following type [Child]",
+            );
+        });
+
         it('should resolve an instance of the type using the last registered type against the token when configuration allowDuplicateTokens=true.', () => {
             const instance = getInstance();
 
@@ -410,26 +457,6 @@ describe('Injector', () => {
             expect(exception).toBeDefined();
             expect(exception.message).toBe(
                 `Cannot resolve Type with token 'unknownChild' as no types have been registered against that token value`,
-            );
-        });
-
-        it('should throw an exception if the token has already been registered to another type', () => {
-            const instance = getInstance();
-            let exception: any;
-            try {
-                instance.register(GrandParent, {
-                    tokens: ['duplicateToken'],
-                });
-                instance.register(Parent, {
-                    tokens: ['duplicateToken'],
-                });
-            } catch (ex) {
-                exception = ex;
-            }
-
-            expect(exception).toBeDefined();
-            expect(exception.message).toBe(
-                `Cannot register Type 'Parent' with token duplicateToken. Duplicate token found for the following type 'GrandParent'`,
             );
         });
     });


### PR DESCRIPTION
This PR fills a gap when registering types for injection using tokens.  Previously only strings where supported, strings have a tendency to conflict on large code bases and therefore a more robust solution is required.  Symbols are now standard in most browsers and can be used with confidence however will require a polyfil for some older browsers.  

This PR does not use Symbols internally, therefore if a developer is not using Symbols for their registrations no polyfill will be required.   As part of implementing this PR I noticed that the new Symbols resolution revealed a an issue with resolving types in scoped scenarios. Therefore this PR includes fixes to make the resolution process both more robust as well as increasing performance by avoiding muliple tree walks through ancestors.  

```typescript
const instance = getInstance();
const strategySymbol = Symbol.for('my-test-strategy');

instance.register(Strategy1, { strategy: strategySymbol});
instance.register(Strategy2, { strategy: strategySymbol});

const strategies = instance.getStrategies(strategySymbol);
expect(strategies).toBeDefined();
expect(strategies.length).toBe(2);
```

