### PR TITLE
Support for @Optional injection annotations

### DIFF
--- a/main/annotations/optional.ts
+++ b/main/annotations/optional.ts
@@ -1,0 +1,23 @@
+import { v4 as uuid } from 'uuid';
+import { getRootInjector } from '../core/util.functions';
+
+/**
+ * The @Optional annotation allows you signal to the injector that you are ok with an undefined value if the type has not been registered with the injector
+ *
+ * constructor(@Optional() thing?: Thing) {}
+ */
+export function Optional() {
+    // the original decorator
+    function optional(target: any, property: string | symbol | undefined, index: number): void {
+        getRootInjector().tokenCache.register({
+            token: `optional_${uuid()}`,
+            owner: target,
+            property,
+            index,
+            injectionType: 'optional',
+        });
+    }
+
+    // return the decorator
+    return optional;
+}

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -7,7 +7,7 @@ export type StringOrSymbol = string | symbol;
 
 export type InstanceFactory = () => InstanceType<any>;
 
-export type InjectionType = 'singleton' | 'multiple' | 'factory' | 'lazy';
+export type InjectionType = 'singleton' | 'multiple' | 'factory' | 'lazy' | 'optional';
 
 export type Newable = new (...args: any[]) => any;
 
@@ -15,6 +15,9 @@ export type Newable = new (...args: any[]) => any;
  * Constructor options allows passing of partial params to injector for construction
  */
 export interface IConstructionOptions<T extends Newable, TParams = Partial<ConstructorParameters<T>>> {
+    /**
+     * Param values to use when constructing the type
+     */
     params?: TParams;
 }
 
@@ -129,6 +132,11 @@ export interface ITokenCache {
      */
     getLazyTokens(type: any): IParameterInjectionToken[];
     /**
+     * Get a list of associated lazy parameter tokens for the given constructor of a type
+     * @param type
+     */
+    getOptionalTokens(type: any): IParameterInjectionToken[];
+    /**
      * Gets a list of tokens this type has be registered against
      */
     getTokensForType(type: any): IInjectionToken[];
@@ -195,22 +203,27 @@ export interface IInjector {
     registerInstance<T extends Newable>(type: any, instance: InstanceType<T>, config?: IInjectionConfiguration): this;
 
     /**
-     * Registers a parameter for factory injection.  This maps to the @Factory annotation
+     * Registers a parameter for factory injection. This maps to the @Factory annotation
      */
     registerParamForFactoryInjection(type: any, ownerType: any, index: number): this;
 
     /**
-     * Registers a parameter for lazy injection.  This maps to the @Lazy annotation
+     * Registers a parameter for lazy injection. This maps to the @Lazy annotation
      */
     registerParamForLazyInjection(type: any, ownerType: any, index: number): this;
 
     /**
-     * Registers a parameter for token injection.  This maps to the @Inject annotation
+     * Registers a parameter for optional injection. This maps to the @Optional annotation
+     */
+    registerParamForOptionalInjection(ownerType: any, index: number): this;
+
+    /**
+     * Registers a parameter for token injection. This maps to the @Inject annotation
      */
     registerParamForTokenInjection(token: StringOrSymbol, ownerType: any, index: number): this;
 
     /**
-     * Registers a parameter for strategy injection.  This maps to the @Strategy annotation
+     * Registers a parameter for strategy injection. This maps to the @Strategy annotation
      */
     registerParamForStrategyInjection(strategy: StringOrSymbol, ownerType: any, index: number): this;
     /**
@@ -254,6 +267,11 @@ export interface IInjector {
         ancestry?: any[],
         options?: IConstructionOptions<T>,
     ): InstanceType<T>;
+
+    /***
+     * Gets an instance of a type or returns undefined if no registration
+     */
+    getOptional<T extends Newable>(type: T): InstanceType<T> | undefined;
 
     /**
      * Returns an Array of the all types registered in the container

--- a/main/core/tokens.ts
+++ b/main/core/tokens.ts
@@ -16,6 +16,7 @@ export class InjectionTokensCache implements ITokenCache {
     private strategyParameterTokens = new Map<any, IParameterInjectionToken[]>();
     private factoryParameterTokens = new Map<any, IParameterInjectionToken[]>();
     private lazyParameterTokens = new Map<any, IParameterInjectionToken[]>();
+    private optionalParameterTokens = new Map<any, IParameterInjectionToken[]>();
     // Fast reverse lookups.  Need to improve
     private typeToTokens = new Map<any, IInjectionToken[]>();
     private tokensToTypes = new Map<StringOrSymbol, any[]>();
@@ -36,6 +37,11 @@ export class InjectionTokensCache implements ITokenCache {
     public getLazyTokens(type: any): IParameterInjectionToken[] {
         return [...(this.lazyParameterTokens.get(type) || [])];
     }
+
+    public getOptionalTokens(type: any): IParameterInjectionToken[] {
+        return [...(this.optionalParameterTokens.get(type) || [])];
+    }
+
     public getTokensForType(type: any): IInjectionToken[] {
         return [...(this.typeToTokens.get(type) || [])];
     }
@@ -77,6 +83,7 @@ export class InjectionTokensCache implements ITokenCache {
         this.strategyConsumers.clear();
         this.factoryParameterTokens.clear();
         this.lazyParameterTokens.clear();
+        this.optionalParameterTokens.clear();
     }
 
     /**
@@ -108,6 +115,8 @@ export class InjectionTokensCache implements ITokenCache {
             this.factoryParameterTokens.set(metadata.owner, [...this.getFactoryTokens(metadata.owner), metadata]);
         } else if (metadata.injectionType === 'lazy') {
             this.lazyParameterTokens.set(metadata.owner, [...this.getLazyTokens(metadata.owner), metadata]);
+        } else if (metadata.injectionType === 'optional') {
+            this.optionalParameterTokens.set(metadata.owner, [...this.getOptionalTokens(metadata.owner), metadata]);
         }
     }
 }

--- a/main/index.ts
+++ b/main/index.ts
@@ -3,6 +3,7 @@ export * from './annotations/injectable';
 export * from './annotations/strategy';
 export * from './annotations/factory';
 export * from './annotations/lazy';
+export * from './annotations/optional';
 export * from './core/factory';
 export * from './core/lazy';
 export * from './core/metadata.functions';

--- a/readme.md
+++ b/readme.md
@@ -474,6 +474,11 @@ class Car {
 }
 ```
 
+You can also resolve an optional injectable using the `getOptional` method on the injector api.  
+
+```typescript
+const car = injector.getOptional(Car) //Undefined
+```
 
 # Register instance
 

--- a/readme.md
+++ b/readme.md
@@ -408,6 +408,8 @@ carWithEmptyEngine.engine === undefined //True
 carWithNoEngine.engine === null //True
 ```
 
+`IMPORTANT`: You can only pass undefined to constructor params which either support injection or default value.  Type safety must be adhered to so `SuperPowerfulEngine` in this case must extend `Engine` type to be valid to the compiler.
+
 # Lazy injection
 
 In certain situations, constructing the entire dependency tree can either be expensive or alternatively might introduce side effects you want to avoid.  In those cases `Lazy` injectables can be useful. Lazy injectables provide a placeholder injection type of `LazyInstance<T>` which will only construct the target injectable when its value property is read. 
@@ -451,7 +453,27 @@ class CarManufacturer {
 }
 ```
 
-`IMPORTANT`: You can only pass undefined to constructor params which either support injection or default value.  Type safety must be adhered to so `SuperPowerfulEngine` in this case must extend `Engine` type to be valid to the compiler.
+# Optional injection
+
+In some environments it will not always be the case that an injectable type has been registered with the injector.  For these scenarios you can leverage the `@Optional` annotation which will allow the injector to resolve `undefined` if no matching registration can be found. 
+
+## Registering an Optional Injectable
+
+All constructor types can be used with optional injection.  There is no special registration required. 
+
+## Resolve an optional injectable
+
+We can use the `@Optional` annotation to signal to the injector that we would like it to resolve `undefined` if no registrations can be found. Below is an example of a constructor for a Car type which supports optional storage.  
+
+```typescript
+@Injectable()
+class Car {
+    constructor(@Optional() private storage?: Storage) {
+        console.log(storage) //Undefined
+    }
+}
+```
+
 
 # Register instance
 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -135,8 +135,10 @@ class CarManufacturer {
 
     constructor(@Factory(Car) private carFactory: AutoFactory<typeof Car>) {}
 
-    public makeCar(): void {
-        this.cars.push(this.carFactory.create());
+    public makeCar(): Car {
+        const car = this.carFactory.create();
+        this.cars.push(car);
+        return car;
     }
 }
 
@@ -807,6 +809,102 @@ describe('Injector', () => {
         });
     });
 
+    describe('Optional', () => {
+        it('should resolve the type instance for parameter decorated with @Optional and has been registered', () => {
+            const instance = getInstance();
+
+            instance
+                .register(GrandParent)
+                .register(Parent)
+                .register(Child)
+                .registerParamForOptionalInjection(Parent, 0);
+
+            const grandParent = instance.get(GrandParent);
+
+            expect(grandParent).toBeDefined();
+            expect(grandParent.son).toBeDefined();
+            expect(grandParent.son.daughter).toBeDefined();
+        });
+
+        it('should resolve undefined when getOptional invoked on injector and no registrations', () => {
+            const instance = getInstance();
+
+            const child = instance.getOptional(Child);
+
+            expect(child).toBeUndefined();
+        });
+
+        it('should resolve instance of type when getOptional invoked on injector has registrations', () => {
+            const instance = getInstance();
+
+            instance.register(Child);
+
+            const child = instance.getOptional(Child);
+
+            expect(child).toBeDefined();
+        });
+
+        it('should throw exception if we try and resolve optional type but its children are not registered', () => {
+            const instance = getInstance();
+            let message = '';
+            instance.register(GrandParent);
+
+            try {
+                instance.getOptional(GrandParent);
+            } catch (ex) {
+                message = ex.message;
+            }
+
+            expect(message).toBe(
+                `Cannot construct Type 'Parent' with ancestry 'GrandParent -> Parent' the type is either not decorated with @Injectable or injector.register was not called for the type or the constructor param is not marked @Optional`,
+            );
+        });
+
+        it('should resolve undefined instance for parameter decorated with @Optional and has NOT been registered', () => {
+            const instance = getInstance();
+
+            instance
+                .register(GrandParent)
+                .register(Parent)
+                .registerParamForOptionalInjection(Parent, 0);
+
+            const grandParent = instance.get(GrandParent);
+
+            expect(grandParent).toBeDefined();
+            expect(grandParent.son).toBeDefined();
+            expect(grandParent.son.daughter).toBeUndefined();
+        });
+
+        it('should still inject a Factory<T> when param is marked @Factory & @optional', () => {
+            const instance = getInstance();
+
+            instance
+                .register(Car)
+                .register(Engine)
+                .register(CarManufacturer)
+                .registerParamForFactoryInjection(Car, CarManufacturer, 0);
+
+            const carManufacturer = instance.get(CarManufacturer);
+            const car = carManufacturer.makeCar();
+
+            expect(car).toBeDefined();
+        });
+
+        it('should still inject a Lazy<T> when param is marked @Lazy & @optional', () => {
+            const instance = getInstance();
+
+            instance
+                .register(Engine)
+                .register(Train)
+                .registerParamForLazyInjection(Engine, Train, 0)
+                .registerParamForOptionalInjection(Train, 0);
+
+            const train = instance.get(Train);
+
+            expect(train.engine instanceof LazyInstance).toBeTruthy();
+        });
+    });
+
     describe('Resolution', () => {
         it('should resolve an instance of injector if injector.get invoked with type of Injector', () => {
             const instance = getInstance();
@@ -839,7 +937,7 @@ describe('Injector', () => {
 
             expect(exception).toBeDefined();
             expect(exception.message).toBe(
-                `Cannot construct Type 'Child' with ancestry 'Child' the type is either not decorated with @Injectable or injector.register was not called for the type`,
+                `Cannot construct Type 'Child' with ancestry 'Child' the type is either not decorated with @Injectable or injector.register was not called for the type or the constructor param is not marked @Optional`,
             );
         });
 
@@ -889,7 +987,7 @@ describe('Injector', () => {
 
             expect(exception).toBeDefined();
             expect(exception.message).toBe(
-                `Cannot construct Type 'Parent' with ancestry 'GrandParent -> Parent' the type is either not decorated with @Injectable or injector.register was not called for the type`,
+                `Cannot construct Type 'Parent' with ancestry 'GrandParent -> Parent' the type is either not decorated with @Injectable or injector.register was not called for the type or the constructor param is not marked @Optional`,
             );
         });
 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -12,6 +12,7 @@ import {
     Injector,
     Lazy,
     LazyInstance,
+    Optional,
     Strategy,
 } from '../main';
 import { DI_ROOT_INJECTOR_KEY, NULL_VALUE, UNDEFINED_VALUE } from '../main/constants/constants';
@@ -107,7 +108,7 @@ class Engine {}
 // tslint:disable-next-line:max-classes-per-file
 @Injectable()
 class Car extends Vehicle {
-    constructor(public engine: Engine) {
+    constructor(@Optional() public engine: Engine) {
         super('Car');
     }
 }


### PR DESCRIPTION
This PR adds support for optional injection using the @Optional annotation.  Example useages

```typescript
@Injectable()
class Car {
    constructor(@Optional() private storage?: Storage) {
        console.log(storage) //Undefined
    }
}
```

or via the registration api

```typescript
injector
    .register(GrandParent)
    .register(Parent)
    .registerParamForOptionalInjection(Parent, 0);
```

and 

```typescript
const car = injector.getOptional(Car) //Undefined
```


