### PR TITLE
Support for construction interception

### DIFF
--- a/main/annotations/interceptor.ts
+++ b/main/annotations/interceptor.ts
@@ -1,0 +1,13 @@
+import { getRootInjector } from '../core/util.functions';
+
+/**
+ * This decorator can be used to register interceptors
+ *
+ * @Interceptor()
+ * class ConstructorInterceptor{}
+ */
+export function Interceptor() {
+    return (interceptor: any) => {
+        getRootInjector().registerInterceptor(interceptor);
+    };
+}

--- a/main/annotations/interceptor.ts
+++ b/main/annotations/interceptor.ts
@@ -1,3 +1,4 @@
+import { NewableConstructorInterceptor } from '../contracts/contracts';
 import { getRootInjector } from '../core/util.functions';
 
 /**
@@ -7,7 +8,9 @@ import { getRootInjector } from '../core/util.functions';
  * class ConstructorInterceptor{}
  */
 export function Interceptor() {
-    return (interceptor: any) => {
-        getRootInjector().registerInterceptor(interceptor);
+    return (interceptor: NewableConstructorInterceptor) => {
+        getRootInjector()
+            .register(interceptor)
+            .registerInterceptor(getRootInjector().get(interceptor));
     };
 }

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -452,7 +452,7 @@ export interface IConstructionInterceptor<TTarget extends Newable = any> {
     /**
      * The type targeted for interception
      */
-    target: TTarget;
+    readonly target: TTarget;
 
     /**
      * Invoked before the type is instanced but after its constructor arguments have been resolved

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -11,6 +11,8 @@ export type InjectionType = 'singleton' | 'multiple' | 'factory' | 'lazy' | 'opt
 
 export type Newable = new (...args: any[]) => any;
 
+export type NewableConstructorInterceptor = new (...args: any[]) => IConstructionInterceptor;
+
 /**
  * Constructor options allows passing of partial params to injector for construction
  */

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -188,6 +188,12 @@ export interface IInjector {
     readonly children: Map<InjectorIdentifier, IInjector>;
 
     /**
+     * Registers an interceptor with the root injector
+     * @param interceptor
+     */
+    registerInterceptor(interceptor: IConstructionInterceptor): this;
+
+    /**
      * Registers a type and associated injection config with the the injector
      */
     register(type: any, config?: IInjectionConfiguration): this;
@@ -277,6 +283,12 @@ export interface IInjector {
      * Returns an Array of the all types registered in the container
      */
     getRegisteredTypes(): Array<any>;
+
+    /**
+     * Resolves an registration for a given type if present
+     * @param type
+     */
+    getRegistrationForType(type: any): IInjectionConfiguration | undefined;
 
     /**
      * Returns an Array of strategy types for the given strategy token
@@ -408,4 +420,50 @@ export interface IMetricsProvider extends IMetrics {
      * @param costMs Cost in milliseconds to construct the type
      */
     update(type: any, owner: any, costMs: number): void;
+}
+
+/**
+ * Provides injection context used at the point of creation
+ */
+export interface IInjectionContext<TType extends Newable = any> {
+    /**
+     * The type being constructed
+     */
+    readonly type: TType;
+    /**
+     * The injector this instance is associated too
+     */
+    readonly injector: IInjector;
+    /**
+     * The configuration used during construction
+     */
+    readonly configuration: IInjectionConfiguration;
+    /**
+     * Constructor arguments used for construction
+     */
+    readonly constructorArgs: ConstructorParameters<TType>;
+}
+
+/**
+ * Base constructor injector interceptor interface
+ * @description Constructor Interceptors only fire when cache missed
+ */
+export interface IConstructionInterceptor<TTarget extends Newable = any> {
+    /**
+     * The type targeted for interception
+     */
+    target: TTarget;
+
+    /**
+     * Invoked before the type is instanced but after its constructor arguments have been resolved
+     * @param context Context at point of construction
+     */
+    beforeCreate(context: IInjectionContext<TTarget>): void;
+
+    /**
+     * Invoked directly after the type has been instanced
+     * @param instance The instance of the given type
+     * @param context Context at point of construction
+     */
+    afterCreate(instance: InstanceType<TTarget>, context: IInjectionContext<TTarget>): void;
 }

--- a/main/index.ts
+++ b/main/index.ts
@@ -4,6 +4,7 @@ export * from './annotations/strategy';
 export * from './annotations/factory';
 export * from './annotations/lazy';
 export * from './annotations/optional';
+export * from './annotations/interceptor';
 export * from './core/factory';
 export * from './core/lazy';
 export * from './core/metadata.functions';

--- a/readme.md
+++ b/readme.md
@@ -677,6 +677,45 @@ level1.isDestroyed() //True;
 level2.isDestroyed() //True;
 ```
 
+# Interception
+
+Needle provides support for interception of construction using `interceptors`.  Interceptors provide the ability for developers to hook into a types construction both immediately before and after a type is instanced.  This technique is useful when you need to configure an instance before that instance is injected into downstream consumers. For example, if we had a Car type which injected an Engine, we may wish to call the engine.tune() function before giving to the car instance.  Interceptors are considered global inside of needle.  Therefore if you create multiple scopes each instance being constructed will pass through the same set of interceptors.  
+
+## Creating an interceptor
+
+To create an interceptor is simple, we simply implement an interface called `IConstructionInterceptor` in our class.  The interface is generic and there we can provide the Type that we wish to target as a generic param.  Below is an example interceptor which implements the interface for the Engine type.  
+
+```typescript
+export class EngineInterceptor implements IConstructionInterceptor<typeof Engine> {
+    public target: typeof Engine = Engine;
+    public beforeCreate(context: IInjectionContext<typeof Engine>): void {
+        console.log(context);
+    }
+    public afterCreate(instance: Engine, context: IInjectionContext<typeof Engine>): void {
+        console.log(instance);
+        console.log(context);
+    }
+}
+```
+
+The interface requires we implement 3 members
+
+* `target` -  The type we wish to intercept
+* `beforeCreate` - A method that will be invoked directly before the type instanced and after all its constructor args are resolved. 
+* `afterCreate` -  A method that will be invoked immediately after the target type was instanced.  
+
+Each method call will receive an `injection context` object which provides information about the context of injection. This includes information such as the injector instance resolving the type, the configuration used during construction and an array of constructor args.
+
+## Registering an interceptor
+
+The easiest way to register an interceptor is to simply decorate your class with `@Interceptor()`.  This will automatically register your interceptor with the root injector.  However if you want to use the injector API you can also do as follows.  
+
+```typescript
+injector.registerInterceptor(new EngineInterceptor());
+```
+
+Note, regardless of the scope of the injector this will always register the interceptor in the root injector. You should use either the decorator or the injector API but not both for a given interceptor.  
+
 # Global configuration
 
 ## Max tree depth

--- a/readme.md
+++ b/readme.md
@@ -708,13 +708,18 @@ Each method call will receive an `injection context` object which provides infor
 
 ## Registering an interceptor
 
-The easiest way to register an interceptor is to simply decorate your class with `@Interceptor()`.  This will automatically register your interceptor with the root injector.  However if you want to use the injector API you can also do as follows.  
+There are two ways to register an interceptor in the system, you can either decorate your class with `@Interceptor()`.  The decorator approach essentially makes you interceptor an injectable so that you can inject other dependencies into it.  The other approach is to use the injector API and provide an instance manually. **Note**: Decorated interceptors will be constructed at point of registration.
 
 ```typescript
+//Decorated
+@Interceptor()
+class EngineInterceptor{}
+
+//Explicit
 injector.registerInterceptor(new EngineInterceptor());
 ```
 
-Note, regardless of the scope of the injector this will always register the interceptor in the root injector. You should use either the decorator or the injector API but not both for a given interceptor.  
+**Note**, regardless of the scope of the injector all interceptors will be registered with the the root injector. 
 
 # Global configuration
 

--- a/readme.md
+++ b/readme.md
@@ -687,7 +687,7 @@ To create an interceptor is simple, we simply implement an interface called `ICo
 
 ```typescript
 export class EngineInterceptor implements IConstructionInterceptor<typeof Engine> {
-    public target: typeof Engine = Engine;
+    public readonly target: typeof Engine = Engine;
     public beforeCreate(context: IInjectionContext<typeof Engine>): void {
         console.log(context);
     }

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -1729,6 +1729,15 @@ describe('Injector', () => {
     });
 
     describe('Interception', () => {
+        it('should create the interceptor upon registration when registered with @Interceptor', () => {
+            const instance = getInstance();
+
+            Interceptor()(EngineInterceptor);
+
+            expect(instance.cache.instanceCount).toBe(1);
+            expect(instance.cache.resolve(EngineInterceptor)).toBeDefined();
+        });
+
         it('should call the correct interception methods if interceptor registered', () => {
             const instance = getInstance();
             const interceptor = new EngineInterceptor();

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -1,5 +1,5 @@
 /* INTERNALS */
-import { IInjector } from 'main/contracts/contracts';
+import { IConstructionInterceptor, IInjectionContext, IInjector } from 'main/contracts/contracts';
 import { Configuration } from 'main/core/configuration';
 import { Metrics } from 'main/core/metrics';
 /* INTERNALS */
@@ -10,6 +10,7 @@ import {
     Inject,
     Injectable,
     Injector,
+    Interceptor,
     Lazy,
     LazyInstance,
     Optional,
@@ -140,6 +141,21 @@ class CarManufacturer {
         const car = this.carFactory.create();
         this.cars.push(car);
         return car;
+    }
+}
+
+// tslint:disable-next-line:max-classes-per-file
+@Interceptor()
+export class EngineInterceptor implements IConstructionInterceptor<typeof Engine> {
+    public beforeInvocation = new Array<IInjectionContext<typeof Engine>>();
+    public afterInvocation = new Array<{ instance: Engine; context: IInjectionContext<typeof Engine> }>();
+
+    public target: typeof Engine = Engine;
+    public beforeCreate(context: IInjectionContext<typeof Engine>): void {
+        this.beforeInvocation.push(context);
+    }
+    public afterCreate(instance: Engine, context: IInjectionContext<typeof Engine>): void {
+        this.afterInvocation.push({ instance, context });
     }
 }
 
@@ -1265,7 +1281,7 @@ describe('Injector', () => {
         return Math.floor(Math.random() * (max - min + 1) + min);
     }
 
-    describe('Scoped injection', () => {
+    describe('Depth Tests', () => {
         const testCount = 10;
 
         type ITestRun = { depth: number; registrationLevel: number; resolutionLevel: number };
@@ -1443,6 +1459,110 @@ describe('Injector', () => {
                 });
             });
 
+            describe('Interception', () => {
+                describe('with interceptor registered in parent and type resolved from scope', () => {
+                    generateTestExecutionData().forEach(test => {
+                        it(`Should intercept the construction - ${getTestInfoAsText(test)}`, () => {
+                            const instance = getInstance(true, test.depth);
+                            const parent = instance.getScope(`level-${test.registrationLevel}`)!;
+                            const scope = parent.getScope(`level-${test.resolutionLevel}`)!;
+                            const interceptor = new EngineInterceptor();
+
+                            parent.registerInterceptor(interceptor);
+                            parent.register(Engine);
+                            const registration = parent.getRegistrationForType(Engine);
+
+                            const engine = scope.get(Engine);
+
+                            expect(engine).toBeDefined();
+                            expect(interceptor.beforeInvocation.length).toBe(1);
+                            expect(interceptor.beforeInvocation[0]).toBeDefined();
+                            expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+                            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+                            expect(interceptor.beforeInvocation[0].injector).toBe(parent);
+                            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+                            expect(interceptor.afterInvocation.length).toBe(1);
+                            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+                            expect(interceptor.afterInvocation[0].context).toBeDefined();
+                            expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+                            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+                            expect(interceptor.afterInvocation[0].context.injector).toBe(parent);
+                            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+                        });
+                    });
+                });
+
+                describe('with interceptor registered in scope and type resolved from parent', () => {
+                    generateTestExecutionData().forEach(test => {
+                        it(`Should intercept the construction - ${getTestInfoAsText(test)}`, () => {
+                            const instance = getInstance(true, test.depth);
+                            const parent = instance.getScope(`level-${test.registrationLevel}`)!;
+                            const scope = parent.getScope(`level-${test.resolutionLevel}`)!;
+                            const interceptor = new EngineInterceptor();
+
+                            scope.registerInterceptor(interceptor);
+                            parent.register(Engine);
+                            const registration = parent.getRegistrationForType(Engine);
+
+                            const engine = scope.get(Engine);
+
+                            expect(engine).toBeDefined();
+                            expect(interceptor.beforeInvocation.length).toBe(1);
+                            expect(interceptor.beforeInvocation[0]).toBeDefined();
+                            expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+                            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+                            expect(interceptor.beforeInvocation[0].injector).toBe(parent);
+                            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+                            expect(interceptor.afterInvocation.length).toBe(1);
+                            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+                            expect(interceptor.afterInvocation[0].context).toBeDefined();
+                            expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+                            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+                            expect(interceptor.afterInvocation[0].context.injector).toBe(parent);
+                            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+                        });
+                    });
+                });
+
+                describe('with interceptor registered directly in root and type resolved from parent and scope', () => {
+                    generateTestExecutionData().forEach(test => {
+                        it(`Should intercept the construction only once - ${getTestInfoAsText(test)}`, () => {
+                            const root = getInstance(true, test.depth);
+                            const parent = root.getScope(`level-${test.registrationLevel}`)!;
+                            const scope = parent.getScope(`level-${test.resolutionLevel}`)!;
+                            const interceptor = new EngineInterceptor();
+
+                            root.registerInterceptor(interceptor);
+                            parent.register(Engine);
+                            const registration = parent.getRegistrationForType(Engine);
+
+                            const engine = scope.get(Engine);
+                            const engine2 = scope.get(Engine);
+
+                            expect(engine).toBeDefined();
+                            expect(engine2).toBeDefined();
+                            expect(engine2 === engine).toBeTruthy();
+                            expect(interceptor.beforeInvocation.length).toBe(1);
+                            expect(interceptor.beforeInvocation[0]).toBeDefined();
+                            expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+                            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+                            expect(interceptor.beforeInvocation[0].injector).toBe(parent);
+                            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+                            expect(interceptor.afterInvocation.length).toBe(1);
+                            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+                            expect(interceptor.afterInvocation[0].context).toBeDefined();
+                            expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+                            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+                            expect(interceptor.afterInvocation[0].context.injector).toBe(parent);
+                            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+                        });
+                    });
+                });
+            });
+
             describe('Overriding', () => {
                 describe('with register.instance() override in a scope', () => {
                     generateTestExecutionData().forEach(test => {
@@ -1604,6 +1724,147 @@ describe('Injector', () => {
                         });
                     });
                 });
+            });
+        });
+    });
+
+    describe('Interception', () => {
+        it('should call the correct interception methods if interceptor registered', () => {
+            const instance = getInstance();
+            const interceptor = new EngineInterceptor();
+
+            instance.register(Engine).registerInterceptor(interceptor);
+
+            instance.get(Engine);
+
+            expect(interceptor.beforeInvocation.length).toBe(1);
+            expect(interceptor.beforeInvocation[0]).toBeDefined();
+            expect(interceptor.beforeInvocation[0].configuration).toBe(instance.getRegistrationForType(Engine)!);
+            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+            expect(interceptor.beforeInvocation[0].injector).toBe(instance);
+            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+            expect(interceptor.afterInvocation.length).toBe(1);
+            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+            expect(interceptor.afterInvocation[0].context).toBeDefined();
+            expect(interceptor.afterInvocation[0].context.configuration).toBe(instance.getRegistrationForType(Engine)!);
+            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+            expect(interceptor.afterInvocation[0].context.injector).toBe(instance);
+            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+        });
+
+        it('should intercept creation if interceptor registered in root but Type resolved from scope', () => {
+            const instance = getInstance();
+            const interceptor = new EngineInterceptor();
+
+            instance.registerInterceptor(interceptor);
+            const scoped = instance.createScope('scoped').register(Engine);
+
+            scoped.get(Engine);
+            const registration = scoped.getRegistrationForType(Engine);
+
+            expect(interceptor.beforeInvocation.length).toBe(1);
+            expect(interceptor.beforeInvocation[0]).toBeDefined();
+            expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+            expect(interceptor.beforeInvocation[0].injector).toBe(scoped);
+            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+            expect(interceptor.afterInvocation.length).toBe(1);
+            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+            expect(interceptor.afterInvocation[0].context).toBeDefined();
+            expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+            expect(interceptor.afterInvocation[0].context.injector).toBe(scoped);
+            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+        });
+
+        it('should always register interceptors in root even if registered via a scope', () => {
+            const root = getInstance();
+            const interceptor = new EngineInterceptor();
+
+            root.register(Engine)
+                .createScope('scoped')
+                .registerInterceptor(interceptor);
+
+            root.get(Engine);
+            const registration = root.getRegistrationForType(Engine);
+
+            expect(interceptor.beforeInvocation.length).toBe(1);
+            expect(interceptor.beforeInvocation[0]).toBeDefined();
+            expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+            expect(interceptor.beforeInvocation[0].injector).toBe(root);
+            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+            expect(interceptor.afterInvocation.length).toBe(1);
+            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+            expect(interceptor.afterInvocation[0].context).toBeDefined();
+            expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+            expect(interceptor.afterInvocation[0].context.injector).toBe(root);
+            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+        });
+
+        it('should register an interceptor instance only one time in the system', () => {
+            const root = getInstance();
+            const interceptor = new EngineInterceptor();
+
+            root.register(Engine)
+                .registerInterceptor(interceptor)
+                .createScope('scoped')
+                .registerInterceptor(interceptor)
+                .registerInterceptor(interceptor);
+
+            root.get(Engine);
+            const registration = root.getRegistrationForType(Engine);
+
+            expect(interceptor.beforeInvocation.length).toBe(1);
+            expect(interceptor.beforeInvocation[0]).toBeDefined();
+            expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+            expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+            expect(interceptor.beforeInvocation[0].injector).toBe(root);
+            expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+            expect(interceptor.afterInvocation.length).toBe(1);
+            expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+            expect(interceptor.afterInvocation[0].context).toBeDefined();
+            expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+            expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+            expect(interceptor.afterInvocation[0].context.injector).toBe(root);
+            expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
+        });
+
+        it('should register duplicate type instances for interception', () => {
+            const root = getInstance();
+            const interceptor1 = new EngineInterceptor();
+            const interceptor2 = new EngineInterceptor();
+            const interceptor3 = new EngineInterceptor();
+
+            root.register(Engine)
+                .registerInterceptor(interceptor1)
+                .createScope('scoped')
+                .registerInterceptor(interceptor2)
+                .registerInterceptor(interceptor3);
+
+            root.get(Engine);
+            const registration = root.getRegistrationForType(Engine);
+
+            [interceptor1, interceptor2, interceptor3].forEach(interceptor => {
+                expect(interceptor.beforeInvocation.length).toBe(1);
+                expect(interceptor.beforeInvocation[0]).toBeDefined();
+                expect(interceptor.beforeInvocation[0].configuration).toBe(registration!);
+                expect(interceptor.beforeInvocation[0].constructorArgs).toEqual([]);
+                expect(interceptor.beforeInvocation[0].injector).toBe(root);
+                expect(interceptor.beforeInvocation[0].type).toBe(Engine);
+
+                expect(interceptor.afterInvocation.length).toBe(1);
+                expect(interceptor.afterInvocation[0].instance instanceof Engine).toBeTruthy();
+                expect(interceptor.afterInvocation[0].context).toBeDefined();
+                expect(interceptor.afterInvocation[0].context.configuration).toBe(registration!);
+                expect(interceptor.afterInvocation[0].context.constructorArgs).toEqual([]);
+                expect(interceptor.afterInvocation[0].context.injector).toBe(root);
+                expect(interceptor.afterInvocation[0].context.type).toBe(Engine);
             });
         });
     });


### PR DESCRIPTION
This PR adds base level support for interceptions.  Primarily construction interceptors.  This supports scenarios where developers require two stage initialization.  Currently not supporting sub classing.  I can do this later but didn't seem super urgent. 

All interceptors are registered in the root and will execute for for target types constructed in scopes.  See readme for usage notes.  