### PR TITLE
Move version back to alpha with (alpha major) change.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/needle",
-    "version": "1.0.0",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "0.2.0",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",


### PR DESCRIPTION
I want to release the new version under alpha still but I don't want existing installs to pick up the changes.  Semver spec states that Alpha version number 0.x.x  use the minor as a major indicator.  Therefore by resetting this to 0.2.0 we can release still under alpha and then avoid installs of ^0.1.0 picking up this version.  