### PR TITLE
Support for external resolution strategies at type level

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     "editor.detectIndentation": false,
     "typescript.tsdk": "node_modules\\typescript\\lib",
     "tslint.configFile": "tslint.conf.js",
-    "typescript.preferences.importModuleSpecifier": "relative"
+    "typescript.preferences.importModuleSpecifier": "relative",
+    "editor.codeActionsOnSave": {
+        "tslint.autoFixOnSave": true,
+    }
 }

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -339,9 +339,10 @@ export interface IInjectionConfiguration<T = any> {
     strategy?: StringOrSymbol;
 
     /**
-     * Optional custom resolution strategy to be used when instancing this type
+     * Optional resolver which can be either an external resolution config or a type
+     * @description If a type is provided the injector will attempt to substitute the original type with the new one being registered here.
      */
-    resolution?: IExternalResolutionConfiguration<T> | T;
+    resolverConfig?: IExternalResolutionConfiguration<T> | T;
 }
 
 /**

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -13,6 +13,8 @@ export type Newable = new (...args: any[]) => any;
 
 export type NewableConstructorInterceptor = new (...args: any[]) => IConstructionInterceptor;
 
+export type AbstractInstanceType<T> = T extends { prototype: infer U } ? U : never;
+
 /**
  * Constructor options allows passing of partial params to injector for construction
  */
@@ -198,7 +200,7 @@ export interface IInjector {
     /**
      * Registers a type and associated injection config with the the injector
      */
-    register(type: any, config?: IInjectionConfiguration): this;
+    register<T>(type: T, config?: IInjectionConfiguration<T>): this;
 
     /**
      * Get the list of registration
@@ -324,7 +326,7 @@ export interface IInjector {
 /**
  * Injection configuration object used for profiling information and behavior about the injectable to the injector
  */
-export interface IInjectionConfiguration {
+export interface IInjectionConfiguration<T = any> {
     /**
      * A list of tokens that this injectable can be resolved by using the @Inject("token") annotation
      */
@@ -334,22 +336,26 @@ export interface IInjectionConfiguration {
      * The strategy property works in conjunction with the @Strategy("key") annotation and signals that an array of items can be injected under this key
      */
     strategy?: StringOrSymbol;
+
+    /**
+     * Optional custom resolution strategy to be used when instancing this type
+     */
+    resolution?: IExternalResolutionConfiguration<T>;
 }
 
 /**
  * Configuration interface used when defining external resolution strategy
  */
-export interface IExternalResolutionConfiguration {
-    /**
-     * The resolver function to be used when instancing types
-     */
-    resolver: (type: any, currentInjector: IInjector, locals?: any) => any;
-
+export interface IExternalResolutionConfiguration<T = any> {
     /**
      * Flag that when set to true will sync instances with the injectors cache.
      * @description By default no cache syncing is done
      */
     cacheSyncing?: boolean;
+    /**
+     * The resolver function to be used when instancing types
+     */
+    resolver(type: T, currentInjector: IInjector, locals?: any): AbstractInstanceType<T>;
 }
 
 /**

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -339,10 +339,10 @@ export interface IInjectionConfiguration<T = any> {
     strategy?: StringOrSymbol;
 
     /**
-     * Optional resolver which can be either an external resolution config or a type
+     * Optional resolution strategy which can be either an external resolution config or a type
      * @description If a type is provided the injector will attempt to substitute the original type with the new one being registered here.
      */
-    resolverConfig?: IExternalResolutionConfiguration<T> | T;
+    resolution?: IExternalResolutionConfiguration<T> | T;
 }
 
 /**

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -9,7 +9,7 @@ export type InstanceFactory = () => InstanceOfType<any>;
 
 export type InjectionType = 'singleton' | 'multiple' | 'factory' | 'lazy' | 'optional';
 
-export type Newable = new (...args: any[]) => any;
+export type Newable<T = any, T2 extends T = T> = new (...args: any[]) => T2;
 
 export type NewableConstructorInterceptor = new (...args: any[]) => IConstructionInterceptor;
 
@@ -341,7 +341,7 @@ export interface IInjectionConfiguration<T = any> {
     /**
      * Optional custom resolution strategy to be used when instancing this type
      */
-    resolution?: IExternalResolutionConfiguration<T>;
+    resolution?: IExternalResolutionConfiguration<T> | T;
 }
 
 /**

--- a/main/core/cache.ts
+++ b/main/core/cache.ts
@@ -1,9 +1,9 @@
-import { ICache, Newable } from '../contracts/contracts';
+import { ICache, InstanceOfType } from '../contracts/contracts';
 
 export class InstanceCache implements ICache {
     private instanceMap = new Map<any, any>();
 
-    public resolve<T extends Newable>(type: T): InstanceType<T> {
+    public resolve<T>(type: T): InstanceOfType<T> {
         return this.instanceMap.get(type);
     }
 

--- a/main/core/guards.ts
+++ b/main/core/guards.ts
@@ -1,4 +1,5 @@
 import {
+    IExternalResolutionConfiguration,
     IFactoryParameterInjectionToken,
     IInjectionToken,
     IInjector,
@@ -46,6 +47,14 @@ export function isLazyParameterToken(
  */
 export function isStringOrSymbol(item: any): item is StringOrSymbol {
     return typeof item === 'string' || typeof item === 'symbol';
+}
+
+/**
+ * Determines if a given value is an external resolution config
+ * @param item
+ */
+export function isExternalResolutionConfigurationLike(item: any): item is IExternalResolutionConfiguration {
+    return typeof item != null && item.resolver != null && typeof item.resolver === 'function';
 }
 
 /**

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -139,11 +139,11 @@ export class Injector implements IInjector {
     public register(type: any, config: IInjectionConfiguration = defaultInjectionConfiguration): this {
         // Make a shallow copy
         config = { ...config };
-        const resolution = config.resolverConfig;
+        const resolution = config.resolution;
 
         // The resolution strategy for a type can be either a config or a type.  If a just a type we can auto convert to a config
         if (resolution != null && !isExternalResolutionConfigurationLike(resolution)) {
-            config.resolverConfig = {
+            config.resolution = {
                 resolver: (_type, currentInjector, locals) => currentInjector.get(resolution, [], locals),
                 cacheSyncing: true,
             } as IExternalResolutionConfiguration;
@@ -430,8 +430,8 @@ export class Injector implements IInjector {
 
             // Are we going to use the types resolution strategy over the external one
             const externalResolutionStrategy =
-                registration != null && registration.resolverConfig != null
-                    ? registration.resolverConfig
+                registration != null && registration.resolution != null
+                    ? registration.resolution
                     : this.configuration.externalResolutionStrategy;
 
             // If we have no registration for this type then throw error. (note @optional will allow this to pass)

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -139,11 +139,11 @@ export class Injector implements IInjector {
     public register(type: any, config: IInjectionConfiguration = defaultInjectionConfiguration): this {
         // Make a shallow copy
         config = { ...config };
-        const resolution = config.resolution;
+        const resolution = config.resolverConfig;
 
         // The resolution strategy for a type can be either a config or a type.  If a just a type we can auto convert to a config
         if (resolution != null && !isExternalResolutionConfigurationLike(resolution)) {
-            config.resolution = {
+            config.resolverConfig = {
                 resolver: (_type, currentInjector, locals) => currentInjector.get(resolution, [], locals),
                 cacheSyncing: true,
             } as IExternalResolutionConfiguration;
@@ -430,8 +430,8 @@ export class Injector implements IInjector {
 
             // Are we going to use the types resolution strategy over the external one
             const externalResolutionStrategy =
-                registration != null && registration.resolution != null
-                    ? registration.resolution
+                registration != null && registration.resolverConfig != null
+                    ? registration.resolverConfig
                     : this.configuration.externalResolutionStrategy;
 
             // If we have no registration for this type then throw error. (note @optional will allow this to pass)

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -405,7 +405,12 @@ export class Injector implements IInjector {
         if (instance == null) {
             const allowOptional = options != null && options.mode === 'optional';
             const registration = injector.getRegistrationForType(constructorType);
-            const externalResolutionStrategy = this.configuration.externalResolutionStrategy;
+
+            // Are we going to use the types resolution strategy over the external one
+            const externalResolutionStrategy =
+                registration != null && registration.resolution != null
+                    ? registration.resolution
+                    : this.configuration.externalResolutionStrategy;
 
             // If we have no registration for this type then throw error. (note @optional will allow this to pass)
             // (Possible if no injector was found and current one has no registration locally)

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -22,6 +22,7 @@ import {
     IInjector,
     IMetrics,
     InjectorIdentifier,
+    InstanceOfType,
     IParameterInjectionToken,
     ITokenCache,
     Newable,
@@ -181,7 +182,7 @@ export class Injector implements IInjector {
      */
     public registerInstance<T extends Newable>(
         type: any,
-        instance: InstanceType<T>,
+        instance: InstanceOfType<T>,
         config: IInjectionConfiguration = defaultInjectionConfiguration,
     ): this {
         // Auto add the registration details
@@ -282,8 +283,9 @@ export class Injector implements IInjector {
 
         const strategies = [...this.getRegistrations().entries()]
             .filter(([_t, config]) => config.strategy === strategy)
-            .map(([t]) => this.get(t, []));
-        return strategies;
+            .map(([t]) => this.get<T>(t, []));
+
+        return (strategies as unknown) as Array<T>;
     }
 
     /**
@@ -298,23 +300,23 @@ export class Injector implements IInjector {
      * Gets an Lazy<T> for a given type
      * @param type
      */
-    public getLazy<T extends Newable>(type: T): LazyInstance<T> {
-        return new LazyInstance(() => this.get(type));
+    public getLazy<T>(type: T): LazyInstance<T> {
+        return new LazyInstance<T>(() => this.get(type));
     }
 
     /**
      * Resolves a type and optional returns undefined if no registrations present
      */
-    public getOptional<T extends Newable>(type: T): InstanceType<T> | undefined {
-        return this.getImpl(type, [], { mode: 'optional' });
+    public getOptional<T>(type: T): InstanceOfType<T> | undefined {
+        return this.getImpl((type as unknown) as Newable, [], { mode: 'optional' });
     }
 
-    public get<T extends Newable>(
+    public get<T>(
         typeOrToken: T | StringOrSymbol,
         ancestry: any[] = [],
-        options?: IConstructionOptions<T>,
-    ): InstanceType<T> {
-        return this.getImpl(typeOrToken, ancestry, options) as InstanceType<T>;
+        options?: T extends Newable ? IConstructionOptions<T> : never,
+    ): InstanceOfType<T> {
+        return this.getImpl(typeOrToken, ancestry, options) as InstanceOfType<T>;
     }
 
     /**
@@ -365,11 +367,11 @@ export class Injector implements IInjector {
     /**
      * Gets an instance of a given type
      */
-    private getImpl<T extends Newable>(
+    private getImpl<T>(
         typeOrToken: T | StringOrSymbol,
         ancestry: any[] = [],
-        options?: IConstructionOptionsInternal<T>,
-    ): InstanceType<T> | undefined {
+        options?: T extends Newable ? IConstructionOptionsInternal<T> : never,
+    ): InstanceOfType<T> | undefined {
         if (this._isDestroyed) {
             throw new Error(
                 `Invalid operation, the current injector instance is marked as destroyed. Injector Id: [${this.id}]`,
@@ -382,7 +384,9 @@ export class Injector implements IInjector {
 
         const NOT_FOUND = isStringOrSymbol(typeOrToken)
             ? `Cannot resolve Type with token '${typeOrToken.toString()}' as no types have been registered against that token value`
-            : `Cannot resolve Type '${typeOrToken.name}' as no types have been registered against any injectors`;
+            : `Cannot resolve Type '${
+                  (typeOrToken as any).name
+              }' as no types have been registered against any injectors`;
 
         const injector = this.getInjectorForTypeOrToken(this, typeOrToken);
 
@@ -424,7 +428,7 @@ export class Injector implements IInjector {
                     instance = externalResolutionStrategy.resolver(
                         constructorType,
                         injector, // Pass injector so resolver understands the current context (scope, cache etc)
-                        (options || {}).params || [],
+                        ((options || {}) as any).params || [],
                     );
 
                     // Fallback to trying to resolve from our injector
@@ -566,7 +570,7 @@ export class Injector implements IInjector {
         const factoryToken = paramTokens[paramTokens.findIndex(ip => ip.index === index)];
         if (factoryToken != null && isFactoryParameterToken(factoryToken)) {
             return new AutoFactory(
-                factoryToken.factoryTarget,
+                factoryToken.factoryTarget as Newable,
                 injector,
                 // Need to ensure the this pointer is not lost (consider autobind (spread throwing errors :/))
                 (s: any, m: boolean, i?: any, l?: Array<any>, e?: IInjector) => this.createInstance(s, m, i, l, e), // :)

--- a/main/core/lazy.ts
+++ b/main/core/lazy.ts
@@ -1,21 +1,23 @@
+import { InstanceOfType } from '../contracts/contracts';
+
 /**
  * Lazy type is used to resolve a given instance at point of use.
  */
 export class LazyInstance<T> {
-    private _value!: T;
+    private _value!: InstanceOfType<T>;
     private _hasValue = false;
 
-    constructor(private factory: () => T) {}
+    constructor(private factory: () => InstanceOfType<T>) {}
 
     public get hasValue(): boolean {
         return this._hasValue;
     }
 
-    public get value(): T {
+    public get value(): InstanceOfType<T> {
         return this.getValue();
     }
 
-    private getValue(): T {
+    private getValue(): InstanceOfType<T> {
         if (!this._hasValue) {
             this._value = this.factory();
             this._hasValue = true;

--- a/main/core/util.functions.ts
+++ b/main/core/util.functions.ts
@@ -1,5 +1,5 @@
 import { DI_ROOT_INJECTOR_KEY } from '../constants/constants';
-import { IConstructionOptions, IInjector, Newable } from '../contracts/contracts';
+import { IConstructionOptions, IInjector, InstanceOfType, Newable } from '../contracts/contracts';
 import { getGlobal } from './globals';
 
 const globalReference = getGlobal();
@@ -16,11 +16,11 @@ export function getRootInjector(): IInjector {
  * @param ancestry
  * @param options
  */
-export function get<T extends Newable>(
+export function get<T>(
     type: T,
     ancestry: any[] = [],
-    options?: IConstructionOptions<T>,
-): InstanceType<T> {
+    options?: T extends Newable ? IConstructionOptions<T> : never,
+): InstanceOfType<T> {
     return getRootInjector().get(type, ancestry, options);
 }
 
@@ -28,18 +28,18 @@ export function get<T extends Newable>(
  * Gets an instance of a type or returns undefined if no registration
  * @param type The type to be resolved
  */
-export function getOptional<T extends Newable>(type: T): InstanceType<T> | undefined {
+export function getOptional<T extends Newable>(type: T): InstanceOfType<T> | undefined {
     return getRootInjector().getOptional(type);
 }
 
 /***
  * Gets a function which when invoked will return the injectable instance
  */
-export function getLazy<T extends Newable>(
+export function getLazy<T>(
     type: T,
     ancestry: any[] = [],
-    options?: IConstructionOptions<T>,
-): () => InstanceType<T> {
+    options?: T extends Newable ? IConstructionOptions<T> : never,
+): () => InstanceOfType<T> {
     return () => get(type, ancestry, options);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -495,15 +495,15 @@ console.log(instance === vehicle) // True
 
 # External Resolution Strategies
 
-There are times where you may require more granular control of a specific types construction.  This may be because you want to resolve the the type from a different injection container, the type may not be `Newable` consider the case of an abstract class or for a variety of other reasons.   In order to support this, needles injectable config provides a `resolverConfig` property which can be used to specify your own external resolution strategy.
+There are times where you may require more granular control of a specific types construction.  This may be because you want to resolve the the type from a different injection container, the type may not be `Newable` consider the case of an abstract class or for a variety of other reasons.   In order to support this, needles injectable config provides a `resolution` property which can be used to specify your own external resolution strategy.
 
 ## Registering a type for external resolution
 
-If you want to entirely own the process of constructing a given type you can define an `ExternalResolutionStrategy` which will be used in place of needles construction logic.  Below shows an example of registering our own resolution strategy against a given type using the annotation approach.  The `resolverConfig` takes a resolver function where you can perform your custom construction and an additional flag (`cacheSyncing`) signalling to needle if it should store the result in its internal cache. 
+If you want to entirely own the process of constructing a given type you can define an `ExternalResolutionStrategy` which will be used in place of needles construction logic.  Below shows an example of registering our own resolution strategy against a given type using the annotation approach.  The `resolution` takes a resolver function where you can perform your custom construction and an additional flag (`cacheSyncing`) signalling to needle if it should store the result in its internal cache. 
 
 ```typescript
 @Injectable({
-    resolverConfig: {
+    resolution: {
         resolver: (_injector, _args) =>  new SuperCar(),
         cacheSyncing: true,
     }
@@ -517,7 +517,7 @@ The same can be achieved using the injector API.
 import { getRootInjector } from '@morgan-stanley/needle';
 
 getRootInjector().register(SuperCar, {
-    resolverConfig: {
+    resolution: {
         resolver: (_injector, _args) =>  new SuperCar(),
         cacheSyncing: true,
     }
@@ -529,11 +529,11 @@ Some types cannot be constructed directly, these types instead require that we u
 
  In the example below we provide an example of this whereby we have an abstract `Car` class which can be registered to a sub type, in this case `SuperCar`. 
 
-**Note**: The `resolverConfig` property accepts a shorthand version whereby you provide just a compatible type for the super type.  If this is used, needle will automatically do the type substitution for you. This makes overriding a base type very simple. 
+**Note**: The `resolution` property accepts a shorthand version whereby you provide just a compatible type for the super type.  If this is used, needle will automatically do the type substitution for you. This makes overriding a base type very simple. 
 
 ```typescript
 @Injectable({
-    resolverConfig: SuperCar
+    resolution: SuperCar
 })
 abstract class Car  {}
 ```
@@ -543,7 +543,7 @@ Or using the injector API
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
 
-getRootInjector().register(Car, { resolverConfig: SuperCar });
+getRootInjector().register(Car, { resolution: SuperCar });
 ```
 
 In the section under **Global Configuration** you can learn about how you can use **External Resolution Strategies** to delegate construction globally and provide fallback strategies when performing interop with other container systems. 

--- a/readme.md
+++ b/readme.md
@@ -504,10 +504,7 @@ If you want to entirely own the process of constructing a given type you can def
 ```typescript
 @Injectable({
     resolverConfig: {
-         resolver: (_injector, _args) => {
-            invoked = true;
-            return new SuperCar();
-         },
+        resolver: (_injector, _args) =>  new SuperCar(),
         cacheSyncing: true,
     }
 })
@@ -521,10 +518,7 @@ import { getRootInjector } from '@morgan-stanley/needle';
 
 getRootInjector().register(SuperCar, {
     resolverConfig: {
-         resolver: (_injector, _args) => {
-            invoked = true;
-            return new SuperCar();
-         },
+        resolver: (_injector, _args) =>  new SuperCar(),
         cacheSyncing: true,
     }
 });

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -972,7 +972,7 @@ describe('Injector', () => {
             expect(instance.cache.instanceCount).toBe(1);
         });
 
-        it('should return an instance of a subtype in place of a super types registration with a local resolver', () => {
+        it('should return an instance of a subtype in place of a super type using external resolver config', () => {
             const instance = getInstance();
             let invoked = false;
 
@@ -993,6 +993,22 @@ describe('Injector', () => {
             expect(individual instanceof Child).toBeTrue();
             expect(invoked).toBeTrue();
             expect(instance.cache.instanceCount).toBe(1);
+        });
+
+        it('should return an instance of a subtype in place of a super type using just the subtype', () => {
+            const instance = getInstance();
+
+            instance.register(Child).register(Individual, {
+                resolution: Child,
+            });
+
+            const individual = instance.get(Individual);
+
+            expect(individual).toBeDefined();
+            expect(individual.id).toBeDefined();
+            expect(individual instanceof Child).toBeTrue();
+            expect(instance.cache.instanceCount).toBe(2); // Child and the Individual
+            expect(instance.cache.resolve(Individual)).toBe(instance.cache.resolve(Child)); // Same references for Subtype and SuperType in cache
         });
 
         it('should throw an exception if an attempt to resolve a type that is not registered', () => {

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -956,7 +956,7 @@ describe('Injector', () => {
             let invoked = false;
 
             instance.register(Child, {
-                resolverConfig: {
+                resolution: {
                     resolver: (_injector, _args) => {
                         invoked = true;
                         return new Child();
@@ -977,7 +977,7 @@ describe('Injector', () => {
             let invoked = false;
 
             instance.register(Individual, {
-                resolverConfig: {
+                resolution: {
                     resolver: (_injector, _args) => {
                         invoked = true;
                         return new Child();
@@ -999,7 +999,7 @@ describe('Injector', () => {
             const instance = getInstance();
 
             instance.register(Child).register(Individual, {
-                resolverConfig: Child,
+                resolution: Child,
             });
 
             const individual = instance.get(Individual);

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -22,7 +22,9 @@ import { InstanceCache } from '../main/core/cache';
 import { isInjectorLike } from '../main/core/guards';
 import { InjectionTokensCache } from '../main/core/tokens';
 
-export abstract class Individual {}
+export abstract class Individual {
+    public id = Math.floor(Math.random() * 100000 + 1);
+}
 
 export abstract class Student extends Individual {}
 
@@ -970,7 +972,7 @@ describe('Injector', () => {
             expect(instance.cache.instanceCount).toBe(1);
         });
 
-        it('should create an instance of the supertype (abstract) using local resolution strategy providing subtype', () => {
+        it('should return an instance of a subtype in place of a super types registration with a local resolver', () => {
             const instance = getInstance();
             let invoked = false;
 
@@ -987,6 +989,7 @@ describe('Injector', () => {
             const individual = instance.get(Individual);
 
             expect(individual).toBeDefined();
+            expect(individual.id).toBeDefined();
             expect(individual instanceof Child).toBeTrue();
             expect(invoked).toBeTrue();
             expect(instance.cache.instanceCount).toBe(1);

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -956,7 +956,7 @@ describe('Injector', () => {
             let invoked = false;
 
             instance.register(Child, {
-                resolution: {
+                resolverConfig: {
                     resolver: (_injector, _args) => {
                         invoked = true;
                         return new Child();
@@ -977,7 +977,7 @@ describe('Injector', () => {
             let invoked = false;
 
             instance.register(Individual, {
-                resolution: {
+                resolverConfig: {
                     resolver: (_injector, _args) => {
                         invoked = true;
                         return new Child();
@@ -999,7 +999,7 @@ describe('Injector', () => {
             const instance = getInstance();
 
             instance.register(Child).register(Individual, {
-                resolution: Child,
+                resolverConfig: Child,
             });
 
             const individual = instance.get(Individual);


### PR DESCRIPTION
Currently needle supports global level external resolution strategies via the global config.  This PR allows that process to be extended to a per type basis. 

**Why is this needed?** 
Consider I want to register an abstract type with the injector and have it auto resolve a concrete instance.  Using an external resloution strategy on a given type means we can support this and other mechanics easily in the future.  Example below

```typescript
injector.register(Car, { resolution: Mustang});
```
This shorthand registration is implicitly converted to a external resolution strategy behind the scenes.  The equivalent manual resolver would look like

```typesccript
injector.register(Car, {
    resolution: {
        resolver: (_type, currentInjector, locals) => currentInjector.get(Mustang, [], locals)
        cacheSyncing: true,
    }
});
```
So while this makes type overrides very easy for developers, it also allows custom resolution strategies to be implemented by developers if required.  


